### PR TITLE
fix(chat): shrink history window 20→6 and give group rooms memory (private per agent)

### DIFF
--- a/api/services/endpoint_caller.py
+++ b/api/services/endpoint_caller.py
@@ -67,14 +67,21 @@ async def build_history(
 ) -> list[dict]:
     """Fetch last N messages in this room and build an OpenAI-compatible history.
 
-    - Messages from the orchestrator (``alpha``) become ``user`` turns.
-    - Messages from *this* agent become ``assistant`` turns.
-    - Messages from *other* agents in the same room (group chat case) are folded
-      into ``user`` turns prefixed with ``[AgentName]: ...`` so the current agent
-      can see what the rest of the pack has said.
+    Each agent lives in its own private bubble per room: it sees messages
+    from the orchestrator (``alpha``) and from its own prior turns, but never
+    from other agents in the same room. This is intentional — if an agent
+    saw other agents' messages, it would reference or @-mention them and
+    trigger runaway cross-agent chatter. Dispatching decides who gets to
+    speak; history only reconstructs what the called agent already lived.
+
+    - Messages from ``alpha`` → ``user`` turns (even if addressed at another
+      agent in the room — the orchestrator's voice is shared context).
+    - Messages from *this* agent → ``assistant`` turns.
+    - Messages from *other* agents → skipped entirely.
     - Consecutive same-role turns are merged by concatenation so the sequence
       strictly alternates user/assistant, which OpenAI-compatible endpoints
-      require. This preserves content instead of dropping earlier messages.
+      require. This preserves content instead of dropping earlier messages
+      (the old replace-on-collision logic lost rapid-fire orchestrator turns).
     - Leading assistant turns are dropped (OpenAI-compat expects user first).
 
     The default window is intentionally small (6 messages). Larger windows
@@ -97,18 +104,13 @@ async def build_history(
             continue
         if m.sender_role == "alpha":
             raw.append({"role": "user", "content": content})
-        elif m.sender_role == "agent":
-            if m.sender_name == agent_name:
-                raw.append({"role": "assistant", "content": content})
-            else:
-                # Another agent speaking in a group room — fold into a user turn
-                # so the current agent sees the full conversation context.
-                raw.append({"role": "user", "content": f"[{m.sender_name}]: {content}"})
-        # system messages are intentionally skipped
+        elif m.sender_role == "agent" and m.sender_name == agent_name:
+            raw.append({"role": "assistant", "content": content})
+        # Other agents' messages and system messages are intentionally skipped.
 
     # Merge consecutive same-role turns by concatenation (not replacement).
-    # This keeps multiple agents' messages visible in group rooms and preserves
-    # rapid-fire messages from the orchestrator in DMs.
+    # This preserves rapid-fire messages from the orchestrator instead of
+    # dropping all but the last one.
     history: list[dict] = []
     for turn in raw:
         if history and history[-1]["role"] == turn["role"]:

--- a/api/services/endpoint_caller.py
+++ b/api/services/endpoint_caller.py
@@ -59,8 +59,28 @@ def _strip_think(text: str) -> str:
     return _THINK_PATTERN.sub("", text).strip()
 
 
-async def build_history(room: str, agent_name: str, db: AsyncSession, limit: int = 20) -> list[dict]:
-    """Fetch last N messages and build clean alternating user/assistant pairs for this agent."""
+async def build_history(
+    room: str,
+    agent_name: str,
+    db: AsyncSession,
+    limit: int = 6,
+) -> list[dict]:
+    """Fetch last N messages in this room and build an OpenAI-compatible history.
+
+    - Messages from the orchestrator (``alpha``) become ``user`` turns.
+    - Messages from *this* agent become ``assistant`` turns.
+    - Messages from *other* agents in the same room (group chat case) are folded
+      into ``user`` turns prefixed with ``[AgentName]: ...`` so the current agent
+      can see what the rest of the pack has said.
+    - Consecutive same-role turns are merged by concatenation so the sequence
+      strictly alternates user/assistant, which OpenAI-compatible endpoints
+      require. This preserves content instead of dropping earlier messages.
+    - Leading assistant turns are dropped (OpenAI-compat expects user first).
+
+    The default window is intentionally small (6 messages). Larger windows
+    create a quadratic token-cost curve on long conversations because the
+    full prefix is re-sent on every turn.
+    """
     from sqlalchemy import select as sa_select
     result = await db.execute(
         sa_select(Message)
@@ -72,15 +92,27 @@ async def build_history(room: str, agent_name: str, db: AsyncSession, limit: int
 
     raw: list[dict] = []
     for m in msgs:
+        content = (m.content or "").strip()
+        if not content:
+            continue
         if m.sender_role == "alpha":
-            raw.append({"role": "user", "content": m.content or ""})
-        elif m.sender_role == "agent" and m.sender_name == agent_name:
-            raw.append({"role": "assistant", "content": m.content or ""})
+            raw.append({"role": "user", "content": content})
+        elif m.sender_role == "agent":
+            if m.sender_name == agent_name:
+                raw.append({"role": "assistant", "content": content})
+            else:
+                # Another agent speaking in a group room — fold into a user turn
+                # so the current agent sees the full conversation context.
+                raw.append({"role": "user", "content": f"[{m.sender_name}]: {content}"})
+        # system messages are intentionally skipped
 
+    # Merge consecutive same-role turns by concatenation (not replacement).
+    # This keeps multiple agents' messages visible in group rooms and preserves
+    # rapid-fire messages from the orchestrator in DMs.
     history: list[dict] = []
     for turn in raw:
         if history and history[-1]["role"] == turn["role"]:
-            history[-1] = turn
+            history[-1]["content"] = history[-1]["content"] + "\n\n" + turn["content"]
         else:
             history.append(turn)
 
@@ -355,9 +387,11 @@ async def handle_agent_notify(
         json.dumps({"type": "typing", "agent_name": agent.name, "room": room}),
     )
 
-    # History for DM rooms only
+    # Build history for any non-meeting room — DMs and project/group rooms
+    # both benefit from context. Meetings are one-shot broadcast prompts and
+    # intentionally get no prior context.
     history = None
-    if not meeting_id and room.startswith("dm:"):
+    if not meeting_id:
         history = await build_history(room, agent.name, db)
 
     full_text = ""


### PR DESCRIPTION
## Summary

Two bugs in `api/services/endpoint_caller.py`:

- **DMs were bleeding tokens.** Every call prepended the last **20** messages as chat history. For a 20-turn conversation at ~200 tokens/message, that's ~42,000 input tokens for 4,000 tokens of actual content — roughly **10x waste**. Hermes re-tokenized the full prefix every turn.
- **Group rooms had amnesia.** `handle_agent_notify()` only built history when `room.startswith('dm:')`, so project/hunt rooms gave the called agent a cold context on every turn — the agent couldn't remember its own prior turns in the same room.

## Private-bubble design (important — not changed)

Each agent lives in its **own private bubble** per room. It sees messages from the orchestrator (`alpha`) and from its own prior turns, but **never from other agents in the same room**. This is intentional: if Hermione saw Draco's messages, she'd reference or @-mention him in her reply and trigger runaway cross-agent chatter. Dispatching (in the Den) decides who gets to speak; history only reconstructs what the called agent already lived through. This PR **preserves** that behavior — see commit 2.

## Changes

- `build_history()` default `limit` drops from **20 → 6**. Most turns get 90% of their value from the last 4–6 messages and the cost curve is quadratic because the full prefix re-ships every turn.
- `handle_agent_notify()` now builds history for every non-meeting room, not just DMs. **The strict alpha-plus-self filter is unchanged** — group rooms still don't leak other agents' messages into this agent's context. What's fixed is: the called agent now sees *its own* prior turns with alpha in that room instead of starting cold.
- Consecutive same-role turns are now **merged by concatenation** instead of replacement. The old behavior dropped earlier messages when the orchestrator sent several messages back-to-back. Merge preserves all of them.
- Empty-content messages are skipped for robustness.
- Meetings stay one-shot by design (no history built).

## Impact

| Scenario | Before | After |
|---|---|---|
| 20-turn DM, cumulative input tokens | ~42,000 | ~12,600 (−70%) |
| DM across turns: agent remembers its own history | ✅ yes (20 msgs) | ✅ yes (6 msgs) |
| Project room: agent remembers its own prior turns with alpha | ❌ no (amnesia) | ✅ yes |
| Project room: agent sees other agents' messages | ❌ no (by design) | ❌ no (still by design) |
| Orchestrator sends 3 messages in a row | 2 of 3 dropped | all 3 merged |
| Meetings (broadcast prompts) | no history | no history (unchanged) |

## Not in this PR

This is **Levels 1+2** of the three-level fix discussed in planning. **Level 3** — stateful \`session_id\` handshake with Hermes so we stop re-sending history at all — is deferred to a follow-up PR that will land alongside the gateway bridge for slash commands (\`/reset\`, \`/help\`, etc.). Level 3 needs coordinated changes in the Hermes gateway, so it belongs with that work.

## Commits

1. Initial fix — shrank window, built group-room history, merged turns. **Bug:** also folded other agents' messages into user turns, breaking the private-bubble model.
2. Correction — reverted the cross-agent fold. Each agent is back in its own bubble. Everything else from commit 1 stays.

## Test plan

- [ ] After deploy, open a DM with an agent and have a 3–4 turn conversation. Confirm the agent remembers earlier turns.
- [ ] In a project room, talk to agent A across multiple turns. Confirm A remembers its own prior responses.
- [ ] In that same project room, mention agent B. Confirm B does NOT see or reference what A said (private bubble preserved).
- [ ] Send two messages back-to-back in a DM and confirm the agent sees both (not just the second).
- [ ] Verify meetings (scheduled standups) still work as one-shot broadcasts.
- [ ] Check token usage over a few days of real use and confirm a visible drop in per-turn input tokens.