### PR TITLE
fix(mobile): finish sidebar drawer and pin chat input for iOS keyboard

### DIFF
--- a/dashboard/src/components/Sidebar.tsx
+++ b/dashboard/src/components/Sidebar.tsx
@@ -6,7 +6,7 @@ import { useDmNotifications } from '../hooks/useDmNotifications'
 import {
   LayoutDashboard, MessageSquare, Crosshair, Users,
   Settings, LogOut, ExternalLink, ChevronLeft, ChevronRight,
-  ChevronDown, Plus,
+  ChevronDown, Plus, Menu, X,
 } from 'lucide-react'
 import api from '../api'
 
@@ -297,13 +297,30 @@ export function Sidebar() {
 
   return (
     <>
+      {/* Mobile hamburger — hidden on desktop via CSS */}
+      <button
+        className="sidebar-toggle"
+        onClick={() => setOpen(true)}
+        aria-label="Open navigation"
+      >
+        <Menu size={22} />
+      </button>
+
+      {/* Mobile backdrop — only rendered when drawer is open */}
+      {open && (
+        <div
+          className="sidebar-backdrop"
+          onClick={() => setOpen(false)}
+        />
+      )}
+
       <aside
         className={`sidebar ${open ? 'sidebar-open' : ''}`}
         style={{
           width: w, background: 'var(--bg-surface)',
           borderRight: '1px solid var(--border)',
           display: 'flex', flexDirection: 'column', height: '100vh',
-          flexShrink: 0, transition: 'width 0.2s ease', overflow: 'hidden',
+          flexShrink: 0, overflow: 'hidden',
         }}
       >
         {/* Logo row */}
@@ -326,6 +343,14 @@ export function Sidebar() {
               </div>
             )
           }
+          {/* Mobile close — hidden on desktop via CSS */}
+          <button
+            className="sidebar-close"
+            onClick={() => setOpen(false)}
+            aria-label="Close navigation"
+          >
+            <X size={20} />
+          </button>
         </div>
 
         {/* Project Switcher */}

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -146,25 +146,99 @@ code, .mono { font-family: 'JetBrains Mono', monospace; }
   margin: 10px 0;
 }
 
-/* ── Retractable Sidebar (Mobile ≤768px) ─────────────────── */
+/* ── Mobile navigation — base rules ──────────────────────── */
+/*
+ * Hidden on desktop, revealed inside the mobile media query below.
+ * Keeping the defaults here so the cascade is predictable and we don't
+ * rely on CSS-class-without-base-rule.
+ */
+.sidebar {
+  transition: transform 0.25s ease, width 0.2s ease;
+}
+
+.sidebar-toggle {
+  display: none;
+  position: fixed;
+  top: 12px;
+  left: 12px;
+  width: 44px;
+  height: 44px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-surface);
+  color: var(--text-primary);
+  cursor: pointer;
+  align-items: center;
+  justify-content: center;
+  z-index: 1003;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+.sidebar-toggle:active { background: var(--bg-hover); }
+
+.sidebar-backdrop {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 1001;
+}
+
+.sidebar-close {
+  display: none;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 0;
+  min-width: 44px;
+  min-height: 44px;
+  align-items: center;
+  justify-content: center;
+}
+.sidebar-close:active { color: var(--text-primary); }
+
+/* ── Den chat area — base rules (no-op on desktop) ───────── */
+.den-input-wrapper {
+  position: relative;
+}
+.den-messages-area {
+  flex: 1;
+  overflow-y: auto;
+}
+
+/* ── Retractable Sidebar + Den input fix (≤768px) ────────── */
 @media (max-width: 768px) {
   .sidebar {
     position: fixed !important;
     left: 0;
     top: 0;
+    height: 100dvh;
     z-index: 1002;
     transform: translateX(-100%);
   }
   .sidebar.sidebar-open {
     transform: translateX(0);
   }
-  .sidebar-toggle {
-    display: flex !important;
+  .sidebar-toggle { display: flex !important; }
+  .sidebar-backdrop { display: block !important; }
+  .sidebar-close { display: flex !important; }
+
+  /*
+   * Chat input: pin to the bottom of the visual viewport so the iOS keyboard
+   * doesn't hide it. Messages get extra bottom padding to compensate.
+   * env(safe-area-inset-bottom) handles the iPhone home indicator.
+   */
+  .den-input-wrapper {
+    position: fixed !important;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: var(--bg-surface);
+    border-top: 1px solid var(--border);
+    padding-bottom: env(safe-area-inset-bottom);
+    z-index: 100;
   }
-  .sidebar-backdrop {
-    display: block !important;
-  }
-  .sidebar-close {
-    display: block !important;
+  .den-messages-area {
+    padding-bottom: 110px !important;
   }
 }

--- a/dashboard/src/pages/Den.tsx
+++ b/dashboard/src/pages/Den.tsx
@@ -859,7 +859,7 @@ export function Den() {
         </div>
 
         {/* Messages */}
-        <div style={{ flex: 1, overflowY: 'auto', padding: '16px 20px' }}>
+        <div className="den-messages-area" style={{ flex: 1, overflowY: 'auto', padding: '16px 20px' }}>
           {messages.length === 0 && (
             <div style={{ textAlign: 'center', color: 'var(--text-muted)', marginTop: 60, fontSize: 14 }}>
               <div style={{ fontSize: 40, marginBottom: 12 }}>🐺</div>
@@ -974,7 +974,7 @@ export function Den() {
         )}
 
         {/* Input with hints overlay */}
-        <div style={{ position: 'relative' }}>
+        <div className="den-input-wrapper" style={{ position: 'relative' }}>
           {/* Persistent command usage hint bar */}
           {activeCommand && activeCommand.usage && slashHints.length === 0 && (
             <div style={{


### PR DESCRIPTION
## Summary

**Phase 1 + Phase 2** of the mobile-responsive plan. Makes the dashboard actually usable on a phone by finishing the half-built sidebar drawer and pinning the Den's chat input above the iOS keyboard. All changes are gated behind `@media (max-width: 768px)` — **zero visual change on desktop**.

## What was broken

**Main sidebar drawer was half-built.** `dashboard/src/index.css` already had a media query with drawer CSS (`translateX(-100%)`, `.sidebar-open`, etc.) but **no JSX rendered a hamburger button, backdrop, or close button**. On mobile the sidebar silently slid off-screen with no way to bring it back — the whole app was unnavigable on a phone. Someone started the work and never finished it.

**Chat input died under the iOS keyboard.** The Den's input lived in normal flex flow. When iOS Safari's on-screen keyboard appeared (~264px tall), the input was pushed below the visual viewport and the user couldn't see what they were typing.

## What the audit got wrong

My earlier responsiveness audit flagged Den's `ChatSidebar` (260px wide) as the #1 offender. It's actually **dead code** — defined in `Den.tsx` but commented out in the render tree (`{/* <ChatSidebar /> */}`). No fix needed there; the audit was reading the function definition without checking whether it was rendered. Noted in the commit so the next person doesn't chase the same ghost.

## Changes

### `dashboard/src/index.css` (+76 lines)

- **Base rules** for `.sidebar-toggle`, `.sidebar-backdrop`, `.sidebar-close` (display: none, positioning, sizing). Previously the mobile media query set `display: flex/block !important` with no base rule, relying on 'these elements don't exist in the DOM' as the desktop-hiding strategy — which broke the moment I started rendering them.
- `transition: transform 0.25s` on `.sidebar` so the drawer slides in smoothly instead of snapping.
- `.den-input-wrapper` + `.den-messages-area` base classes (no-op on desktop) plus mobile overrides that pin the input to `bottom: 0` with `env(safe-area-inset-bottom)` padding for the iPhone home indicator, and add `padding-bottom: 110px` to the messages area so content isn't occluded.
- Mobile sidebar `height: 100dvh` so it respects iOS Safari's dynamic address bar.

### `dashboard/src/components/Sidebar.tsx` (+22 lines)

- Imported `Menu` and `X` icons from lucide-react.
- Fixed-position hamburger button (`.sidebar-toggle`) rendered **outside** the `<aside>` so it stays reachable when the drawer is closed. 44×44 touch target, top-left, z-index 1003.
- Backdrop `<div>` (`.sidebar-backdrop`) when open — tap to close.
- Close X button (`.sidebar-close`) inside the logo row, pulled right by the existing `space-between` justify. Hidden on desktop via base rule.
- Removed the inline `transition: 'width 0.2s ease'` from the `<aside>` inline style since the CSS class now handles both width and transform transitions.

### `dashboard/src/pages/Den.tsx` (+2 lines)

- `className='den-messages-area'` on the messages scroll container.
- `className='den-input-wrapper'` on the input's positioned parent. Kept the inline `position: relative` for desktop; mobile media query overrides with `position: fixed !important`.

## Desktop regression check

None of the CSS changes apply above 768px. The only JSX changes on desktop are:
- Three new elements in the Sidebar render tree (`.sidebar-toggle`, `.sidebar-backdrop`, `.sidebar-close`), all with `display: none` on desktop.
- Two new `className` attributes on Den divs that map to no-op CSS classes on desktop.

**Net behavioral change on desktop: zero.** If the desktop layout looks different after merging, something's wrong with the cascade — please flag.

## What's still not mobile-friendly (later phases)

- **Phase 3** — Touch target sweep (Pack card edit buttons, HuntBoard task icons, ChatInput paperclip/send)
- **Phase 4** — HuntBoard detail panel (340px fixed overlay) → bottom sheet
- **Phase 5** — Context menu tap-to-open fallback for Den message actions; Login card 5px overflow on 375px viewports

## Test plan

- [ ] Chrome DevTools responsive mode at **375×667** (iPhone SE)
  - [ ] Sidebar should be off-screen on first load
  - [ ] Hamburger button visible top-left (44×44 clickable area)
  - [ ] Tap hamburger → sidebar slides in from the left, backdrop fades in
  - [ ] Tap backdrop → sidebar slides out
  - [ ] Tap X close button → sidebar slides out
  - [ ] Tap any nav item → sidebar closes automatically (existing behavior, preserved)
- [ ] Navigate to `/den` on the small viewport
  - [ ] Input should be pinned to the bottom edge of the viewport
  - [ ] Messages area should have enough bottom padding that the last message isn't hidden behind the input
  - [ ] Tap the input → keyboard pops up → input should stay visible above the keyboard (test on a real iPhone if possible — DevTools doesn't simulate the visual viewport perfectly)
- [ ] Check `/agents`, `/hunt`, `/settings` pages: they'll still be somewhat broken (those are phases 3-5), but the main sidebar navigation should work on all of them
- [ ] **Desktop regression**: open at **1440×900** and confirm the sidebar, chat input, and everything else looks identical to before this PR

## Deploy

```bash
# After merging
ssh ubuntu@57.131.47.66
cd ~/akela-ai
git pull
sudo docker compose -f docker-compose.prod.yml up -d --build dashboard
```

Dashboard is the only service that needs a rebuild (api/worker/landing are unchanged).