### PR TITLE
fix(mobile): Dashboard, Tasks, Pack edit, Meetings, Settings responsiveness

### DIFF
--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -274,4 +274,13 @@ code, .mono { font-family: 'JetBrains Mono', monospace; }
     border-left: none !important;
     height: 100%;
   }
+
+  /*
+   * Dashboard grid: desktop is a 1fr + 320px 2-column layout. On mobile the
+   * 320px right rail squeezed the left content to ~55px, so stack as a single
+   * column and let the pack roster flow below projects.
+   */
+  .dashboard-grid {
+    grid-template-columns: 1fr !important;
+  }
 }

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -317,4 +317,25 @@ code, .mono { font-family: 'JetBrains Mono', monospace; }
     flex: 1 1 auto !important;
     min-width: 0 !important;
   }
+
+  /*
+   * Meetings page: desktop is a 2-column layout with a 280px left config
+   * list and a flex: 1 right detail panel. On mobile, stack them and let
+   * the whole page scroll vertically so both list and detail are usable.
+   */
+  .meetings-container {
+    flex-direction: column !important;
+    overflow-y: auto !important;
+    overflow-x: hidden !important;
+  }
+  .meetings-left-panel {
+    width: 100% !important;
+    border-right: none !important;
+    border-bottom: 1px solid var(--border);
+    flex-shrink: 0 !important;
+  }
+  .meetings-right-panel {
+    padding: 16px !important;
+    flex-shrink: 0 !important;
+  }
 }

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -300,4 +300,21 @@ code, .mono { font-family: 'JetBrains Mono', monospace; }
     min-width: 260px;
     scroll-snap-align: start;
   }
+
+  /*
+   * Form row utility — stacks a horizontal flex row of form fields into
+   * a vertical column on mobile. Hardcoded child widths (e.g. width: 100
+   * for a slug/rank select) get overridden to 100% so every field uses the
+   * full width of the screen. Used in Pack.tsx edit panel and Settings.tsx
+   * project form.
+   */
+  .form-row-stack {
+    flex-direction: column !important;
+    align-items: stretch !important;
+  }
+  .form-row-stack > div {
+    width: 100% !important;
+    flex: 1 1 auto !important;
+    min-width: 0 !important;
+  }
 }

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -283,4 +283,21 @@ code, .mono { font-family: 'JetBrains Mono', monospace; }
   .dashboard-grid {
     grid-template-columns: 1fr !important;
   }
+
+  /*
+   * Tasks kanban: 5 columns at flex: 1 each would squeeze to ~70px on a
+   * 375px phone. Instead, let the container scroll horizontally and give
+   * each column a sensible minimum width with scroll-snap so swipes land
+   * cleanly on a column boundary.
+   */
+  .tasks-kanban {
+    overflow-x: auto !important;
+    scroll-snap-type: x mandatory;
+    -webkit-overflow-scrolling: touch;
+  }
+  .tasks-kanban > div {
+    flex: 0 0 auto !important;
+    min-width: 260px;
+    scroll-snap-align: start;
+  }
 }

--- a/dashboard/src/pages/Dashboard.tsx
+++ b/dashboard/src/pages/Dashboard.tsx
@@ -213,7 +213,7 @@ export function Dashboard() {
         Pack overview · all projects
       </p>
 
-      <div style={{ display: 'grid', gridTemplateColumns: '1fr 320px', gap: 24 }}>
+      <div className="dashboard-grid" style={{ display: 'grid', gridTemplateColumns: '1fr 320px', gap: 24 }}>
 
         {/* Left: all projects */}
         <div>

--- a/dashboard/src/pages/Meetings.tsx
+++ b/dashboard/src/pages/Meetings.tsx
@@ -176,9 +176,9 @@ export function Meetings() {
   }
 
   return (
-    <div style={{ display: 'flex', height: '100%', overflow: 'hidden' }}>
+    <div className="meetings-container" style={{ display: 'flex', height: '100%', overflow: 'hidden' }}>
       {/* ── Left panel: standup config list ── */}
-      <div style={{
+      <div className="meetings-left-panel" style={{
         width: 280, borderRight: '1px solid var(--border)', display: 'flex', flexDirection: 'column',
         background: 'var(--bg-surface)', flexShrink: 0,
       }}>
@@ -276,7 +276,7 @@ export function Meetings() {
       </div>
 
       {/* ── Right panel: config detail + run history ── */}
-      <div style={{ flex: 1, overflowY: 'auto', padding: 28 }}>
+      <div className="meetings-right-panel" style={{ flex: 1, overflowY: 'auto', padding: 28 }}>
         {!selected ? (
           <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: '100%', color: 'var(--text-muted)' }}>
             <Mic2 size={40} style={{ marginBottom: 12, opacity: 0.3 }} />

--- a/dashboard/src/pages/Pack.tsx
+++ b/dashboard/src/pages/Pack.tsx
@@ -179,7 +179,7 @@ function AgentCard({ agent, onDelete, onUpdate, readOnly = false }: {
       {/* Edit panel */}
       {editing && (
         <div style={{ marginTop: 8 }}>
-          <div style={{ display: 'flex', gap: 8, marginBottom: 8 }}>
+          <div className="form-row-stack" style={{ display: 'flex', gap: 8, marginBottom: 8 }}>
             <div style={{ flex: 1 }}>
               <div style={{ fontSize: 10, color: 'var(--text-muted)', marginBottom: 4 }}>DISPLAY NAME</div>
               <input value={editDisplayName} onChange={e => setEditDisplayName(e.target.value)} style={inputStyle} />
@@ -198,7 +198,7 @@ function AgentCard({ agent, onDelete, onUpdate, readOnly = false }: {
             <div style={{ fontSize: 10, color: 'var(--text-muted)', marginBottom: 4 }}>SKILLS (comma-separated)</div>
             <input value={editSkills} onChange={e => setEditSkills(e.target.value)} style={inputStyle} />
           </div>
-          <div style={{ display: 'flex', gap: 8, marginBottom: 4 }}>
+          <div className="form-row-stack" style={{ display: 'flex', gap: 8, marginBottom: 4 }}>
             <div style={{ flex: 2 }}>
               <div style={{ fontSize: 10, color: 'var(--text-muted)', marginBottom: 4 }}>ENDPOINT URL</div>
               <input value={editEndpoint} onChange={e => setEditEndpoint(e.target.value)} placeholder="http://..." style={inputStyle} />
@@ -219,7 +219,7 @@ function AgentCard({ agent, onDelete, onUpdate, readOnly = false }: {
             <div style={{ fontSize: 10, color: 'var(--text-muted)', marginBottom: 4 }}>BEARER TOKEN <span style={{ fontWeight: 400 }}>(optional — sent as Authorization header)</span></div>
             <input value={editBearerToken} onChange={e => setEditBearerToken(e.target.value)} placeholder="Leave blank if not required" type="password" style={inputStyle} />
           </div>
-          <div style={{ display: 'flex', gap: 8, marginBottom: 8 }}>
+          <div className="form-row-stack" style={{ display: 'flex', gap: 8, marginBottom: 8 }}>
             <div style={{ flex: 1 }}>
               <div style={{ fontSize: 10, color: 'var(--text-muted)', marginBottom: 4 }}>MODEL</div>
               <input value={editModel} onChange={e => setEditModel(e.target.value)} placeholder="e.g. MiniMax-M2.7" style={inputStyle} />

--- a/dashboard/src/pages/Settings.tsx
+++ b/dashboard/src/pages/Settings.tsx
@@ -74,7 +74,7 @@ function ProjectSettings() {
 
   return (
     <div>
-      <div style={{ display: 'flex', gap: 12, marginBottom: 14 }}>
+      <div className="form-row-stack" style={{ display: 'flex', gap: 12, marginBottom: 14 }}>
         <div style={{ flex: 1 }}>
           <div style={{ fontSize: 12, color: 'var(--text-muted)', marginBottom: 6 }}>PROJECT NAME</div>
           <input

--- a/dashboard/src/pages/Tasks.tsx
+++ b/dashboard/src/pages/Tasks.tsx
@@ -268,7 +268,7 @@ export function Tasks() {
           <div style={{ fontSize: 15 }}>Select a project in the sidebar to see the prey.</div>
         </div>
       ) : (
-        <div style={{ flex: 1, display: 'flex', gap: 0, overflow: 'hidden' }}>
+        <div className="tasks-kanban" style={{ flex: 1, display: 'flex', gap: 0, overflow: 'hidden' }}>
           {WOLF_COLUMNS.map((col, i) => {
             const colTasks = tasks.filter(t => t.status === col.status)
             return (


### PR DESCRIPTION
## Summary

Closes out the remaining five pages that still had mobile issues after PR #3. Each fix is its own commit so they're bisectable. All changes gate on `@media (max-width: 768px)` — **zero desktop visual change**. This PR completes the original 5-phase mobile plan.

## Commits

### 1. `c584820` — Dashboard grid stacks on mobile
- **File:** `dashboard/src/pages/Dashboard.tsx` (+1) and `dashboard/src/index.css` (+9)
- **Problem:** `gridTemplateColumns: '1fr 320px'` — the fixed 320px pack-roster rail left ~55px for projects on a 375px phone
- **Fix:** `.dashboard-grid` class with `grid-template-columns: 1fr !important` on mobile so the pack roster stacks below

### 2. `1b9d423` — Tasks kanban scrolls horizontally with snap
- **File:** `dashboard/src/pages/Tasks.tsx` (+1) and `dashboard/src/index.css` (+17)
- **Problem:** 5 columns at `flex: 1` each squeezed to ~70px on mobile — unreadable, untappable
- **Fix:** `.tasks-kanban` class switches to `overflow-x: auto` and gives each column `min-width: 260px` with CSS scroll-snap so swipes land cleanly on a column boundary
- **UX:** swipe left/right to change column; tap cards normally

### 3. `572c810` — Pack agent edit panel form rows stack
- **File:** `dashboard/src/pages/Pack.tsx` (+3) and `dashboard/src/index.css` (+17)
- **Problem:** Three flex rows in the inline edit panel had hardcoded child widths (`width: 100` for RANK, `width: 130` for PROTOCOL) that broke on narrow viewports
- **Fix:** added a **reusable** `.form-row-stack` utility class that flips `flex-direction: row` → `column` on mobile and overrides child widths to 100%. Applied to all three edit-panel rows: DISPLAY NAME+RANK, ENDPOINT+PROTOCOL, MODEL+WORKSPACE URL
- **Bonus:** Settings reuses this same class in commit 5

### 4. `5c3eeba` — Meetings page stacks panels on mobile
- **File:** `dashboard/src/pages/Meetings.tsx` (+3) and `dashboard/src/index.css` (+18)
- **Problem:** Fixed 280px left config panel + `flex: 1` right detail panel left ~95px for the detail on a 375px phone
- **Fix:** `.meetings-container` / `.meetings-left-panel` / `.meetings-right-panel` classes flip the container to `flex-direction: column` and override `overflow: hidden` → `overflow-y: auto` so the whole page can scroll. Config list stacks on top, detail below.

### 5. `2a98f6d` — Settings project form row stacks
- **File:** `dashboard/src/pages/Settings.tsx` (+1, CSS already added in commit 3)
- **Problem:** Flex row with `flex: 1` PROJECT NAME input + hardcoded `width: 100` SLUG input squeezed both fields on narrow screens
- **Fix:** reused the `.form-row-stack` utility class from commit 3. One-line JSX change, no new CSS.

## Desktop regression check

Every CSS change is gated behind `@media (max-width: 768px)`. The new classNames on JSX elements are no-ops on desktop because the CSS rules don't apply above the breakpoint. Specifically:

| Class | Desktop (>768px) behavior |
|---|---|
| `.dashboard-grid` | No rule matches — keeps inline `1fr 320px` |
| `.tasks-kanban` | No rule matches — keeps inline `flex, overflow: hidden` |
| `.form-row-stack` | No rule matches — keeps inline `flex-direction: row` |
| `.meetings-container` | No rule matches — keeps inline `flex, overflow: hidden` |
| `.meetings-left-panel` | No rule matches — keeps inline `width: 280` |
| `.meetings-right-panel` | No rule matches — keeps inline `flex: 1, padding: 28` |

Visual test at **1440×900** should be byte-identical to before this PR. Please call out anything different.

## Test plan

Chrome DevTools responsive mode at **375×667** (iPhone SE):

- [ ] **Dashboard (`/`)** — Projects list and THE PACK section stack vertically, both readable
- [ ] **Tasks (`/tasks` or equivalent)** — 5 columns visible by swiping horizontally; swipe snaps to column boundaries
- [ ] **Pack edit** — Tap pencil on an agent card, expand the edit panel. DISPLAY NAME + RANK stacked vertically. ENDPOINT URL + PROTOCOL stacked. MODEL + WORKSPACE URL stacked. All inputs readable and editable.
- [ ] **Meetings (`/meetings`)** — Config list at top full-width, detail panel below. Tap a config in the list → scroll down to see detail
- [ ] **Settings** — PROJECT NAME and SLUG inputs stacked vertically
- [ ] **Desktop regression** — resize to 1440×900, verify Dashboard, Tasks, Pack, Meetings, Settings all look identical to pre-PR

## Deploy

```bash
# After merging, on the VPS:
cd ~/akela-ai
git pull
sudo docker compose -f docker-compose.prod.yml up -d --build dashboard
```

Only the dashboard service needs a rebuild.

## What's left after this merges

**Nothing from the mobile plan.** All 5 phases + this "cleanup pass" complete. Dashboard is fully mobile-usable end-to-end. Next natural step is **PWA wrap** (manifest.json + service worker + Web Push for notifications) whenever you want the "installable on home screen + push notifications" layer. That's its own PR / discussion.