### PR TITLE
feat: PWA + Web Push notifications (installable dashboard)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,19 @@ GITHUB_REDIRECT_URI=http://localhost:8200/akela-api/auth/github/callback
 AKELA_DOMAIN=your-domain.example.com
 # Email for Let's Encrypt certificate issuance.
 ACME_EMAIL=you@example.com
+
+# --- Web Push (optional) ---
+# Enables the "🔔 Notifications" opt-in in Settings. Users install the
+# PWA to their home screen, enable notifications, and get pushes when
+# events fire on the backend. If these are blank, the feature is
+# gracefully disabled — the rest of Akela keeps working.
+#
+# Generate a keypair once with:
+#   docker compose -f docker-compose.prod.yml exec api vapid --gen
+# That prints a public key (urlsafe_base64) and writes private_key.pem.
+# Copy the values here and delete the .pem file from the container.
+VAPID_PUBLIC_KEY=
+VAPID_PRIVATE_KEY=
+# Email for the VAPID subject claim — push services use this to contact
+# you if your notifications cause problems. Use a real address.
+VAPID_SUBJECT=mailto:you@example.com

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ project ([hermes-agent](https://github.com/balaji-embedcentrum/hermes-agent)).
 | **Trust scores** | Every completed task updates an agent's trust score. Restricted / Omega / Delta tiers gate what work the agent can pick up |
 | **GitHub OAuth login** | Sign in with your GitHub account (optional — local auth also works) |
 | **Project rooms** | Group agents into isolated projects with their own chat, tasks, and memberships |
+| **Installable PWA** | Add the dashboard to your phone's home screen, launches full-screen, works offline for the shell |
+| **Web Push notifications** | Optional. Opt in from Settings → receive pushes when backend events fire (requires VAPID keys in `.env`) |
 
 ---
 
@@ -164,6 +166,71 @@ akela-ai/
 
 ---
 
+## PWA & Web Push notifications
+
+Akela's dashboard ships as a Progressive Web App. You can **install it to
+your phone's home screen** and it behaves like a native app (launches
+full-screen, has its own icon, works offline for the shell).
+
+### Install
+
+1. Open `https://<your-domain>/pack` in Chrome / Safari / Edge on your device
+2. **iOS:** Safari → Share → *Add to Home Screen*
+3. **Android / Desktop Chrome:** address bar → *Install Akela* button (or Menu → *Install app*)
+
+No App Store, no Play Store, no native build — same web code.
+
+### Enable push notifications (optional)
+
+Akela can send Web Push notifications when things happen on the backend
+(agent comes online, task completed, etc.). Setup is two pieces:
+
+**1. Server side — generate VAPID keys and put them in `.env`.**
+
+VAPID is the Web Push authentication scheme. You generate a keypair once,
+keep the private key secret on the server, and the public key gets baked
+into every notification so push services trust it came from you.
+
+```bash
+# One-time, on the VPS:
+cd ~/akela-ai
+sudo docker compose -f docker-compose.prod.yml exec api vapid --gen
+```
+
+`vapid --gen` prints a public key (urlsafe base64) and writes
+`private_key.pem` to the current directory. Copy the public key to
+`VAPID_PUBLIC_KEY` in `.env`, copy the contents of `private_key.pem` to
+`VAPID_PRIVATE_KEY`, and set `VAPID_SUBJECT=mailto:you@example.com`. Then
+delete the `.pem` file from the container. Restart the api container:
+
+```bash
+sudo docker compose -f docker-compose.prod.yml up -d api
+```
+
+**2. Client side — opt in from Settings.**
+
+1. Open the dashboard → **Settings → 🔔 Notifications**
+2. Click **Enable notifications** → browser asks for permission → allow
+3. Click **Send test notification** — a push should arrive in a few seconds
+
+**iOS caveat:** Safari only supports Web Push for PWAs that are installed
+to the home screen. If the "Enable notifications" button does nothing on
+iOS, you haven't installed Akela yet — go back to the Install section.
+
+### What triggers notifications
+
+As of this release, only the **Send test notification** button fires one.
+Automatic notifications on task/agent events are coming in a follow-up
+release. When wired, the backend calls
+`api.services.push.send_to_orchestrator(...)` with a title, body, and URL;
+every subscribed device owned by that orchestrator receives the push.
+
+If you want to skip Web Push entirely, leave `VAPID_PUBLIC_KEY` and
+`VAPID_PRIVATE_KEY` blank. The Settings UI shows a "not configured"
+message and the feature silently disables — everything else keeps working.
+
+---
+
 ## Database migrations
 
 SQLAlchemy creates tables on first boot via `create_all_tables()`. For schema
@@ -190,6 +257,8 @@ for the full list. The most important ones:
 | `GITHUB_REDIRECT_URI` | Must match the OAuth app's callback URL |
 | `AKELA_DOMAIN` | Public domain (Traefik routes on this in prod) |
 | `ACME_EMAIL` | Let's Encrypt registration email |
+| `VAPID_PUBLIC_KEY` / `VAPID_PRIVATE_KEY` | Web Push keypair. Generate with `vapid --gen` inside the api container. Leave blank to disable Push entirely. |
+| `VAPID_SUBJECT` | `mailto:you@example.com` — contact address push services use if your pushes misbehave |
 
 ---
 

--- a/api/config.py
+++ b/api/config.py
@@ -27,6 +27,18 @@ class Settings(BaseSettings):
     trust_omega_max: float = 60.0
     trust_delta_max: float = 85.0
 
+    # Web Push (VAPID). Generate a keypair with:
+    #   python -c "from py_vapid import Vapid; v = Vapid(); v.generate_keys(); \
+    #     print('private:', v.private_key.private_numbers().private_value); \
+    #     print('public:', v.public_key_urlsafe_base64().decode())"
+    # Or simpler, use the 'vapid' CLI that ships with py-vapid:
+    #   vapid --gen
+    # Leave blank to disable Web Push entirely — the /push/* endpoints will
+    # return 503 and the frontend hides the notification opt-in.
+    vapid_public_key: str = ""
+    vapid_private_key: str = ""
+    vapid_subject: str = "mailto:admin@example.com"
+
     class Config:
         env_file = ".env"
         extra = "ignore"

--- a/api/main.py
+++ b/api/main.py
@@ -7,7 +7,7 @@ import redis.asyncio as aioredis
 
 from api.config import get_settings
 from api.db.session import create_all_tables
-from api.routers import auth, orchestrators, agents, chat, meetings, trust, conversations, hunt, bridge, projects
+from api.routers import auth, orchestrators, agents, chat, meetings, trust, conversations, hunt, bridge, projects, push
 
 settings = get_settings()
 
@@ -54,6 +54,7 @@ app.include_router(conversations.router)
 app.include_router(hunt.router)
 app.include_router(bridge.router)
 app.include_router(projects.router)
+app.include_router(push.router)
 
 
 @app.get("/")

--- a/api/models/__init__.py
+++ b/api/models/__init__.py
@@ -5,11 +5,12 @@ from api.models.feedback import MessageFeedback
 from api.models.meeting import Meeting, MeetingType, MeetingStatus
 from api.models.trust_event import TrustEvent, AgentTrustScore
 from api.models.conversation import Workspace, Conversation
+from api.models.push_subscription import PushSubscription
 
 __all__ = [
     "Orchestrator", "Agent", "AgentStatus", "AgentRank",
     "Message", "MessageFeedback", "Meeting", "MeetingType",
     "MeetingStatus", "TrustEvent", "AgentTrustScore",
-    "Workspace", "Conversation",
+    "Workspace", "Conversation", "PushSubscription",
 ]
 

--- a/api/models/push_subscription.py
+++ b/api/models/push_subscription.py
@@ -1,0 +1,35 @@
+import uuid
+from datetime import datetime
+from sqlalchemy import String, DateTime, ForeignKey, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.dialects.postgresql import UUID
+from api.db.session import Base
+
+
+class PushSubscription(Base):
+    """
+    A Web Push subscription registered by a user's browser.
+
+    One orchestrator can have multiple subscriptions (phone, laptop, tablet).
+    The endpoint URL is unique — if the same browser re-subscribes we update
+    the existing row instead of inserting a duplicate.
+    """
+
+    __tablename__ = "push_subscriptions"
+    __table_args__ = (UniqueConstraint("endpoint", name="uq_push_endpoint"),)
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    orchestrator_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("orchestrators.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    # Push service endpoint URL — where we POST to deliver a message.
+    endpoint: Mapped[str] = mapped_column(String, nullable=False)
+    # Keys from the browser's PushSubscription.getKey() output (base64url).
+    p256dh: Mapped[str] = mapped_column(String, nullable=False)
+    auth: Mapped[str] = mapped_column(String, nullable=False)
+    # Optional user-agent string for display in the settings UI ("iPhone — Safari").
+    user_agent: Mapped[str] = mapped_column(String, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -13,3 +13,5 @@ python-multipart==0.0.9
 aiohttp==3.9.5
 apscheduler==3.10.4
 bcrypt==4.1.3
+pywebpush==2.0.0
+py-vapid==1.9.1

--- a/api/routers/push.py
+++ b/api/routers/push.py
@@ -1,0 +1,164 @@
+"""
+Web Push subscription endpoints.
+
+Frontend flow:
+  1. GET  /push/vapid-public-key      → client uses key to build the
+                                        PushSubscription object
+  2. POST /push/subscribe             → client registers its subscription
+  3. POST /push/test                  → client triggers a test notification
+                                        to verify end-to-end
+  4. POST /push/unsubscribe           → client removes its subscription
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, status, Header
+from pydantic import BaseModel
+from sqlalchemy import select, delete
+from sqlalchemy.ext.asyncio import AsyncSession
+from typing import Optional
+
+from api.config import get_settings
+from api.db.session import get_db
+from api.dependencies import get_current_orchestrator
+from api.models.orchestrator import Orchestrator
+from api.models.push_subscription import PushSubscription
+from api.services.push import send_to_orchestrator
+
+router = APIRouter(prefix="/push", tags=["push"])
+settings = get_settings()
+
+
+class SubscriptionKeys(BaseModel):
+    p256dh: str
+    auth: str
+
+
+class SubscribeRequest(BaseModel):
+    endpoint: str
+    keys: SubscriptionKeys
+
+
+class UnsubscribeRequest(BaseModel):
+    endpoint: str
+
+
+def _check_enabled():
+    if not (settings.vapid_public_key and settings.vapid_private_key):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Web Push is not configured on this server (VAPID keys missing).",
+        )
+
+
+@router.get("/vapid-public-key")
+async def vapid_public_key():
+    """
+    Returns the VAPID public key so the client can use it when subscribing.
+    Called unauthenticated so the Settings page can show the correct
+    'Enable notifications' / 'Not configured' state without waking the
+    subscription flow.
+    """
+    if not settings.vapid_public_key:
+        return {"enabled": False, "public_key": None}
+    return {"enabled": True, "public_key": settings.vapid_public_key}
+
+
+@router.post("/subscribe", status_code=status.HTTP_201_CREATED)
+async def subscribe(
+    data: SubscribeRequest,
+    user_agent: Optional[str] = Header(None, alias="User-Agent"),
+    orch: Orchestrator = Depends(get_current_orchestrator),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Register (or upsert) a push subscription for the logged-in orchestrator.
+    Idempotent: re-subscribing the same endpoint updates the keys instead of
+    creating a duplicate row.
+    """
+    _check_enabled()
+
+    existing = await db.execute(
+        select(PushSubscription).where(PushSubscription.endpoint == data.endpoint)
+    )
+    sub = existing.scalar_one_or_none()
+
+    if sub:
+        sub.p256dh = data.keys.p256dh
+        sub.auth = data.keys.auth
+        sub.orchestrator_id = orch.id
+        sub.user_agent = user_agent
+    else:
+        sub = PushSubscription(
+            orchestrator_id=orch.id,
+            endpoint=data.endpoint,
+            p256dh=data.keys.p256dh,
+            auth=data.keys.auth,
+            user_agent=user_agent,
+        )
+        db.add(sub)
+
+    await db.commit()
+    await db.refresh(sub)
+
+    return {"id": str(sub.id), "created_at": sub.created_at.isoformat()}
+
+
+@router.post("/unsubscribe")
+async def unsubscribe(
+    data: UnsubscribeRequest,
+    orch: Orchestrator = Depends(get_current_orchestrator),
+    db: AsyncSession = Depends(get_db),
+):
+    """Remove a subscription. Scoped to the current orchestrator."""
+    await db.execute(
+        delete(PushSubscription).where(
+            PushSubscription.endpoint == data.endpoint,
+            PushSubscription.orchestrator_id == orch.id,
+        )
+    )
+    await db.commit()
+    return {"detail": "unsubscribed"}
+
+
+@router.post("/test")
+async def send_test(
+    orch: Orchestrator = Depends(get_current_orchestrator),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Deliver a test notification to every subscription registered by the
+    current orchestrator. Useful to verify the full plumbing works after
+    first-time setup.
+    """
+    _check_enabled()
+
+    delivered = await send_to_orchestrator(
+        orch.id,
+        title="Akela — test notification",
+        body="If you see this, Web Push is working. 🐺",
+        url="/pack/",
+        db=db,
+    )
+
+    return {"delivered": delivered}
+
+
+@router.get("/subscriptions")
+async def list_subscriptions(
+    orch: Orchestrator = Depends(get_current_orchestrator),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    List the current orchestrator's subscriptions, for display in Settings.
+    """
+    result = await db.execute(
+        select(PushSubscription).where(PushSubscription.orchestrator_id == orch.id)
+    )
+    subs = result.scalars().all()
+    return [
+        {
+            "id": str(s.id),
+            "user_agent": s.user_agent,
+            "created_at": s.created_at.isoformat(),
+        }
+        for s in subs
+    ]

--- a/api/services/push.py
+++ b/api/services/push.py
@@ -1,0 +1,133 @@
+"""
+Web Push delivery service.
+
+Sends Web Push notifications to all of an orchestrator's registered
+subscriptions using pywebpush + VAPID authentication. Subscriptions that
+return 404/410 from the push service are automatically deleted — those
+are permanently dead (user uninstalled the PWA, revoked permission, or
+changed browsers).
+
+Usage from other routers/services:
+
+    from api.services.push import send_to_orchestrator
+    await send_to_orchestrator(
+        orchestrator_id,
+        title="Task completed",
+        body="Hermione finished task #42",
+        url="/pack/hunt",
+        db=db,
+    )
+
+If VAPID keys are not configured in settings, calls are no-ops (logged
+at WARN level) — the rest of the app keeps working, push just doesn't
+deliver. This mirrors the behavior where GitHub OAuth is optional.
+"""
+
+import json
+import logging
+import uuid
+from typing import Optional
+
+from sqlalchemy import select, delete
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.config import get_settings
+from api.models.push_subscription import PushSubscription
+
+logger = logging.getLogger(__name__)
+settings = get_settings()
+
+
+def _vapid_configured() -> bool:
+    return bool(settings.vapid_private_key and settings.vapid_public_key)
+
+
+async def send_to_orchestrator(
+    orchestrator_id: uuid.UUID | str,
+    *,
+    title: str,
+    body: str,
+    url: str = "/pack/",
+    tag: Optional[str] = None,
+    require_interaction: bool = False,
+    db: AsyncSession,
+) -> int:
+    """
+    Deliver a push notification to every subscription owned by an
+    orchestrator. Returns the number of successful deliveries.
+
+    Dead subscriptions (404/410 from the push service) are removed from
+    the database transparently — nothing calls this function needs to
+    know about subscription lifecycle.
+    """
+    if not _vapid_configured():
+        logger.warning(
+            "push.send_to_orchestrator: VAPID keys not configured, skipping "
+            "(title=%r orchestrator_id=%s)", title, orchestrator_id,
+        )
+        return 0
+
+    # pywebpush is a sync library — import locally so the rest of the app
+    # doesn't pay the cost if Web Push is never used.
+    try:
+        from pywebpush import webpush, WebPushException
+    except ImportError:
+        logger.warning("pywebpush not installed; run `pip install pywebpush`")
+        return 0
+
+    if isinstance(orchestrator_id, str):
+        orchestrator_id = uuid.UUID(orchestrator_id)
+
+    result = await db.execute(
+        select(PushSubscription).where(PushSubscription.orchestrator_id == orchestrator_id)
+    )
+    subs = list(result.scalars().all())
+
+    if not subs:
+        return 0
+
+    payload = json.dumps({
+        "title": title,
+        "body": body,
+        "url": url,
+        "tag": tag or "akela",
+        "requireInteraction": require_interaction,
+    })
+
+    vapid_claims = {"sub": settings.vapid_subject}
+
+    sent = 0
+    dead_endpoints: list[str] = []
+
+    for sub in subs:
+        try:
+            webpush(
+                subscription_info={
+                    "endpoint": sub.endpoint,
+                    "keys": {"p256dh": sub.p256dh, "auth": sub.auth},
+                },
+                data=payload,
+                vapid_private_key=settings.vapid_private_key,
+                vapid_claims=dict(vapid_claims),  # webpush mutates the dict
+                ttl=86400,  # 24h — push service may hold briefly for offline devices
+            )
+            sent += 1
+        except WebPushException as e:
+            # 404/410 = gone permanently, remove from DB.
+            # Other errors (network, 5xx) = transient, leave the subscription.
+            status = getattr(getattr(e, "response", None), "status_code", None)
+            if status in (404, 410):
+                logger.info("push: dropping dead subscription %s (%s)", sub.id, status)
+                dead_endpoints.append(sub.endpoint)
+            else:
+                logger.warning("push: delivery failed for %s: %s", sub.id, e)
+        except Exception as e:
+            logger.warning("push: unexpected error for %s: %s", sub.id, e)
+
+    if dead_endpoints:
+        await db.execute(
+            delete(PushSubscription).where(PushSubscription.endpoint.in_(dead_endpoints))
+        )
+        await db.commit()
+
+    return sent

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -2,9 +2,28 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+
+    <title>Akela</title>
+
+    <!-- Favicon + touch icons -->
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>dashboard</title>
+    <link rel="apple-touch-icon" href="/app-icon.svg" />
+
+    <!-- PWA manifest -->
+    <link rel="manifest" href="/manifest.json" />
+
+    <!-- Theme color: matches the dashboard background so the browser UI
+         blends into the app when installed to a home screen. -->
+    <meta name="theme-color" content="#0d0f14" />
+
+    <!-- iOS standalone mode (Add to Home Screen) -->
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="Akela" />
+
+    <!-- Discouraging Safari's phone-number auto-detection which breaks layouts -->
+    <meta name="format-detection" content="telephone=no" />
   </head>
   <body>
     <div id="root"></div>

--- a/dashboard/nginx.conf
+++ b/dashboard/nginx.conf
@@ -22,4 +22,18 @@ server {
         add_header Cache-Control "no-store, no-cache, must-revalidate";
         try_files $uri =404;
     }
+
+    # Never cache the service worker — if a stale SW gets pinned, users
+    # stay on old code indefinitely. The SW itself decides what to cache.
+    location = /sw.js {
+        add_header Cache-Control "no-store, no-cache, must-revalidate";
+        add_header Service-Worker-Allowed "/pack/";
+        try_files $uri =404;
+    }
+
+    # Manifest should also revalidate quickly so icon/name changes apply fast.
+    location = /manifest.json {
+        add_header Cache-Control "no-cache";
+        try_files $uri =404;
+    }
 }

--- a/dashboard/public/app-icon-maskable.svg
+++ b/dashboard/public/app-icon-maskable.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+  <!--
+    Maskable icon: Android may crop this into a circle, squircle, or
+    rounded square. Keep the important content inside the 80% safe zone
+    (inset 51px on each side).
+  -->
+  <rect width="512" height="512" fill="#0d0f14"/>
+  <text
+    x="256"
+    y="256"
+    font-size="220"
+    text-anchor="middle"
+    dominant-baseline="central"
+    font-family="'Apple Color Emoji', 'Segoe UI Emoji', 'Noto Color Emoji', sans-serif"
+  >🐺</text>
+</svg>

--- a/dashboard/public/app-icon.svg
+++ b/dashboard/public/app-icon.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+  <!-- Background: Akela dark surface -->
+  <rect width="512" height="512" rx="96" fill="#0d0f14"/>
+  <!-- Subtle inner glow ring in alpha orange -->
+  <rect x="24" y="24" width="464" height="464" rx="80" fill="none" stroke="#f5a623" stroke-width="3" opacity="0.4"/>
+  <!-- Wolf emoji — rendered as text so it inherits the system emoji font -->
+  <text
+    x="256"
+    y="256"
+    font-size="320"
+    text-anchor="middle"
+    dominant-baseline="central"
+    font-family="'Apple Color Emoji', 'Segoe UI Emoji', 'Noto Color Emoji', sans-serif"
+  >🐺</text>
+</svg>

--- a/dashboard/public/manifest.json
+++ b/dashboard/public/manifest.json
@@ -1,0 +1,26 @@
+{
+  "name": "Akela",
+  "short_name": "Akela",
+  "description": "Run as one. Self-hosted control plane for your AI agent pack.",
+  "start_url": "/pack/",
+  "scope": "/pack/",
+  "display": "standalone",
+  "orientation": "any",
+  "theme_color": "#0d0f14",
+  "background_color": "#0d0f14",
+  "categories": ["productivity", "developer"],
+  "icons": [
+    {
+      "src": "/pack/app-icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "/pack/app-icon-maskable.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "maskable"
+    }
+  ]
+}

--- a/dashboard/public/sw.js
+++ b/dashboard/public/sw.js
@@ -1,0 +1,131 @@
+/*
+ * Akela service worker
+ *
+ * Responsibilities:
+ *  1. Cache the app shell so the dashboard opens offline (even if it can't
+ *     fetch live data, the UI loads and shows a "connection lost" state).
+ *  2. Handle Web Push notifications from the backend.
+ *  3. Focus/open the dashboard when a notification is clicked.
+ *
+ * Scope: /pack/ (set when main.tsx registers this worker).
+ *
+ * Bump CACHE_VERSION when changing the caching strategy to force clients
+ * to refetch the shell. Hashed asset filenames from Vite are cached
+ * opportunistically in the runtime cache and don't need version bumps.
+ */
+
+const CACHE_VERSION = 'akela-v1';
+const SHELL_CACHE = `${CACHE_VERSION}-shell`;
+const RUNTIME_CACHE = `${CACHE_VERSION}-runtime`;
+
+// App shell — minimum needed to boot the SPA offline.
+const SHELL_URLS = [
+  '/pack/',
+  '/pack/index.html',
+  '/pack/manifest.json',
+  '/pack/app-icon.svg',
+  '/pack/favicon.svg',
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(SHELL_CACHE).then((cache) => cache.addAll(SHELL_URLS)).then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys
+          .filter((k) => k !== SHELL_CACHE && k !== RUNTIME_CACHE)
+          .map((k) => caches.delete(k))
+      )
+    ).then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  const req = event.request;
+
+  // Only GETs go through the cache. POST/PUT/DELETE pass through untouched.
+  if (req.method !== 'GET') return;
+
+  const url = new URL(req.url);
+
+  // API calls: network-first, no caching. Akela data is live and we don't want
+  // to serve stale agents/messages/tasks from the worker cache.
+  if (url.pathname.startsWith('/akela-api/')) return;
+
+  // Only handle requests under /pack/ — stay out of the way of the API and
+  // other services on the same origin.
+  if (!url.pathname.startsWith('/pack/')) return;
+
+  // Navigations: network-first, fall back to cached index.html for offline.
+  if (req.mode === 'navigate') {
+    event.respondWith(
+      fetch(req).catch(() => caches.match('/pack/index.html'))
+    );
+    return;
+  }
+
+  // Static assets (hashed JS/CSS/images): cache-first, with network update.
+  event.respondWith(
+    caches.match(req).then((cached) => {
+      const networked = fetch(req).then((resp) => {
+        if (resp && resp.status === 200 && resp.type === 'basic') {
+          const clone = resp.clone();
+          caches.open(RUNTIME_CACHE).then((cache) => cache.put(req, clone));
+        }
+        return resp;
+      }).catch(() => cached);
+      return cached || networked;
+    })
+  );
+});
+
+// ── Web Push ─────────────────────────────────────────────────────────────
+
+self.addEventListener('push', (event) => {
+  let payload = { title: 'Akela', body: 'You have a new notification' };
+  if (event.data) {
+    try {
+      payload = { ...payload, ...event.data.json() };
+    } catch {
+      payload.body = event.data.text() || payload.body;
+    }
+  }
+
+  const title = payload.title || 'Akela';
+  const options = {
+    body: payload.body || '',
+    icon: '/pack/app-icon.svg',
+    badge: '/pack/app-icon.svg',
+    tag: payload.tag || 'akela',
+    data: { url: payload.url || '/pack/' },
+    requireInteraction: payload.requireInteraction === true,
+  };
+
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  const targetUrl = (event.notification.data && event.notification.data.url) || '/pack/';
+
+  event.waitUntil(
+    self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clientList) => {
+      // If the dashboard is already open in a tab, focus it and navigate there.
+      for (const client of clientList) {
+        if (client.url.includes('/pack/') && 'focus' in client) {
+          client.navigate(targetUrl).catch(() => {});
+          return client.focus();
+        }
+      }
+      // Otherwise open a new window.
+      if (self.clients.openWindow) {
+        return self.clients.openWindow(targetUrl);
+      }
+    })
+  );
+});

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -8,3 +8,22 @@ createRoot(document.getElementById('root')!).render(
     <App />
   </StrictMode>,
 )
+
+// ── PWA service worker registration ─────────────────────────────────────
+//
+// Registered only in production. Scope is /pack/ — same as the app's
+// BrowserRouter basename — so the worker only controls pages under /pack/
+// and never interferes with any other service on the origin.
+//
+// Dev mode skips registration to avoid the "cached stale bundle" pain
+// during hot reloads.
+if ('serviceWorker' in navigator && import.meta.env.PROD) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker
+      .register('/pack/sw.js', { scope: '/pack/' })
+      .catch((err) => {
+        // Don't crash the app if the SW fails to register — log and move on.
+        console.warn('[akela] service worker registration failed:', err)
+      })
+  })
+}

--- a/dashboard/src/pages/Settings.tsx
+++ b/dashboard/src/pages/Settings.tsx
@@ -1,8 +1,16 @@
 import { useStore } from '../store'
 import type { Project, Agent } from '../store'
-import { Copy, Check, Save, Trash2 } from 'lucide-react'
+import { Copy, Check, Save, Trash2, Bell, BellOff } from 'lucide-react'
 import { useState, useEffect } from 'react'
 import api from '../api'
+import {
+  checkSupport as checkPushSupport,
+  getStatus as getPushStatus,
+  enableNotifications,
+  disableNotifications,
+  sendTestNotification,
+  type PushStatus,
+} from '../push'
 
 const COLORS = [
   '#4a9eff', '#f5a623', '#4caf50', '#f44336', '#9c27b0',
@@ -207,6 +215,159 @@ function ProjectSettings() {
   )
 }
 
+function NotificationSettings() {
+  const [status, setStatus] = useState<PushStatus | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [testResult, setTestResult] = useState<'idle' | 'sent' | 'failed'>('idle')
+
+  const refresh = async () => setStatus(await getPushStatus())
+
+  useEffect(() => {
+    if (!checkPushSupport()) {
+      setStatus({
+        supported: false, serverEnabled: false,
+        permission: 'unsupported', subscribed: false,
+      })
+      return
+    }
+    refresh()
+  }, [])
+
+  const handleEnable = async () => {
+    setBusy(true)
+    const ok = await enableNotifications()
+    setBusy(false)
+    if (!ok) {
+      alert('Could not enable notifications. Check that:\n' +
+            '• You granted permission when your browser asked\n' +
+            '• The backend has VAPID keys configured (see SECURITY.md)\n' +
+            '• You are on HTTPS')
+    }
+    await refresh()
+  }
+
+  const handleDisable = async () => {
+    setBusy(true)
+    await disableNotifications()
+    setBusy(false)
+    setTestResult('idle')
+    await refresh()
+  }
+
+  const handleTest = async () => {
+    setBusy(true)
+    const ok = await sendTestNotification()
+    setBusy(false)
+    setTestResult(ok ? 'sent' : 'failed')
+    setTimeout(() => setTestResult('idle'), 3000)
+  }
+
+  if (!status) {
+    return (
+      <div style={{ color: 'var(--text-muted)', fontSize: 13 }}>Checking browser support…</div>
+    )
+  }
+
+  if (!status.supported) {
+    return (
+      <div style={{ color: 'var(--text-muted)', fontSize: 13, lineHeight: 1.6 }}>
+        Your browser doesn't support Web Push notifications. Try a recent version of
+        Chrome, Edge, Firefox, or Safari 16.4+ on iOS (and install Akela to your home
+        screen first).
+      </div>
+    )
+  }
+
+  if (!status.serverEnabled) {
+    return (
+      <div style={{ color: 'var(--text-muted)', fontSize: 13, lineHeight: 1.6 }}>
+        Web Push is not configured on this server — an administrator needs to add VAPID
+        keys to <code style={{ color: 'var(--accent)' }}>.env</code>. See the README
+        section on Web Push for the <code style={{ color: 'var(--accent)' }}>vapid --gen</code> command.
+      </div>
+    )
+  }
+
+  if (status.permission === 'denied') {
+    return (
+      <div style={{ color: 'var(--text-muted)', fontSize: 13, lineHeight: 1.6 }}>
+        Notifications are blocked for this site. Unblock them in your browser's site
+        settings and reload this page.
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 12, marginBottom: 14,
+        padding: '10px 14px', background: 'var(--bg-elevated)',
+        border: '1px solid var(--border)', borderRadius: 8,
+      }}>
+        {status.subscribed
+          ? <Bell size={18} color="var(--success)" />
+          : <BellOff size={18} color="var(--text-muted)" />
+        }
+        <div style={{ flex: 1, fontSize: 13 }}>
+          {status.subscribed
+            ? <span>Notifications are <strong style={{ color: 'var(--success)' }}>enabled</strong> on this device.</span>
+            : <span>Notifications are <strong>off</strong> on this device.</span>
+          }
+        </div>
+      </div>
+
+      <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
+        {!status.subscribed ? (
+          <button
+            onClick={handleEnable}
+            disabled={busy}
+            style={{
+              padding: '10px 16px', background: 'var(--accent)', border: 'none',
+              borderRadius: 6, color: '#fff', fontSize: 13, fontWeight: 600,
+              cursor: busy ? 'wait' : 'pointer', display: 'flex', alignItems: 'center', gap: 8,
+            }}
+          >
+            <Bell size={14} /> Enable notifications
+          </button>
+        ) : (
+          <>
+            <button
+              onClick={handleTest}
+              disabled={busy}
+              style={{
+                padding: '10px 16px', background: 'var(--bg-elevated)',
+                border: '1px solid var(--border)', borderRadius: 6,
+                color: 'var(--text-primary)', fontSize: 13, fontWeight: 600,
+                cursor: busy ? 'wait' : 'pointer', display: 'flex', alignItems: 'center', gap: 8,
+              }}
+            >
+              {testResult === 'sent' ? <Check size={14} color="var(--success)" /> : <Bell size={14} />}
+              {testResult === 'sent' ? 'Test sent' : testResult === 'failed' ? 'Test failed' : 'Send test notification'}
+            </button>
+            <button
+              onClick={handleDisable}
+              disabled={busy}
+              style={{
+                padding: '10px 16px', background: 'rgba(244,67,54,0.1)',
+                border: '1px solid rgba(244,67,54,0.3)', borderRadius: 6,
+                color: '#f44336', fontSize: 13, fontWeight: 600,
+                cursor: busy ? 'wait' : 'pointer', display: 'flex', alignItems: 'center', gap: 8,
+              }}
+            >
+              <BellOff size={14} /> Disable
+            </button>
+          </>
+        )}
+      </div>
+
+      <p style={{ marginTop: 14, fontSize: 11, color: 'var(--text-muted)', lineHeight: 1.6 }}>
+        Notifications arrive on whichever device you enable them on. On iOS, install
+        Akela to your home screen first — Safari only supports Web Push for installed PWAs.
+      </p>
+    </div>
+  )
+}
+
 export function Settings() {
   const { user } = useStore()
   const [copied, setCopied] = useState(false)
@@ -233,6 +394,17 @@ export function Settings() {
           📁 Project Settings
         </h2>
         <ProjectSettings />
+      </div>
+
+      {/* Notifications */}
+      <div style={{
+        background: 'var(--bg-surface)', border: '1px solid var(--border)',
+        borderRadius: 12, padding: 24, marginBottom: 20,
+      }}>
+        <h2 style={{ fontSize: 15, fontWeight: 600, marginBottom: 16 }}>
+          🔔 Notifications
+        </h2>
+        <NotificationSettings />
       </div>
 
       {/* Alpha credentials */}

--- a/dashboard/src/push.ts
+++ b/dashboard/src/push.ts
@@ -1,0 +1,171 @@
+/*
+ * Web Push client helpers.
+ *
+ * Boundary between the browser's Push API and Akela's backend /push/*
+ * endpoints. Keeps Settings.tsx uncluttered — the UI just calls these
+ * functions and handles the boolean/void results.
+ *
+ * The flow:
+ *   1. checkSupport()              — is the browser even capable?
+ *   2. getServerStatus()           — is the backend configured (VAPID keys)?
+ *   3. enableNotifications()       — ask permission → subscribe → POST
+ *   4. sendTestNotification()      — hit /push/test
+ *   5. disableNotifications()      — unsubscribe locally + DELETE server
+ */
+
+import api from './api'
+
+export interface PushStatus {
+  supported: boolean         // browser has Push API + Notification API + service worker
+  serverEnabled: boolean     // backend has VAPID keys configured
+  permission: NotificationPermission | 'unsupported'
+  subscribed: boolean        // there's an active subscription for this browser
+}
+
+function urlBase64ToUint8Array(base64String: string): Uint8Array {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4)
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/')
+  const raw = window.atob(base64)
+  const out = new Uint8Array(raw.length)
+  for (let i = 0; i < raw.length; ++i) out[i] = raw.charCodeAt(i)
+  return out
+}
+
+export function checkSupport(): boolean {
+  return (
+    'serviceWorker' in navigator &&
+    'PushManager' in window &&
+    'Notification' in window
+  )
+}
+
+async function getRegistration(): Promise<ServiceWorkerRegistration | null> {
+  if (!checkSupport()) return null
+  try {
+    // ready resolves when a SW is both installed and active for the scope.
+    return await navigator.serviceWorker.ready
+  } catch {
+    return null
+  }
+}
+
+export async function getStatus(): Promise<PushStatus> {
+  if (!checkSupport()) {
+    return { supported: false, serverEnabled: false, permission: 'unsupported', subscribed: false }
+  }
+
+  // Ask the backend whether VAPID is configured. If not, we still show
+  // the section but disable the toggle with a clear reason.
+  let serverEnabled = false
+  try {
+    const r = await api.get('/push/vapid-public-key')
+    serverEnabled = !!r.data?.enabled
+  } catch {
+    serverEnabled = false
+  }
+
+  const permission = Notification.permission
+  const reg = await getRegistration()
+  const sub = reg ? await reg.pushManager.getSubscription() : null
+
+  return {
+    supported: true,
+    serverEnabled,
+    permission,
+    subscribed: !!sub,
+  }
+}
+
+/**
+ * Full opt-in flow: request permission, subscribe with the server's VAPID
+ * public key, POST the subscription to /push/subscribe. Returns true on
+ * success, false on any failure (caller decides how to surface).
+ */
+export async function enableNotifications(): Promise<boolean> {
+  if (!checkSupport()) return false
+
+  // 1. Request permission (if not already granted)
+  let permission = Notification.permission
+  if (permission === 'default') {
+    permission = await Notification.requestPermission()
+  }
+  if (permission !== 'granted') return false
+
+  // 2. Fetch the server's VAPID public key
+  let publicKey: string | null = null
+  try {
+    const r = await api.get('/push/vapid-public-key')
+    if (!r.data?.enabled) return false
+    publicKey = r.data.public_key
+  } catch {
+    return false
+  }
+  if (!publicKey) return false
+
+  // 3. Subscribe via the browser Push API
+  const reg = await getRegistration()
+  if (!reg) return false
+
+  let subscription: PushSubscription
+  try {
+    // Check for existing subscription first — re-use instead of creating a new one.
+    const existing = await reg.pushManager.getSubscription()
+    subscription = existing || await reg.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: urlBase64ToUint8Array(publicKey),
+    })
+  } catch (e) {
+    console.warn('[akela] push subscribe failed:', e)
+    return false
+  }
+
+  // 4. Send the subscription to the backend so it can send us pushes
+  try {
+    const json = subscription.toJSON() as {
+      endpoint: string
+      keys: { p256dh: string; auth: string }
+    }
+    await api.post('/push/subscribe', {
+      endpoint: json.endpoint,
+      keys: { p256dh: json.keys.p256dh, auth: json.keys.auth },
+    })
+    return true
+  } catch (e) {
+    console.warn('[akela] /push/subscribe failed:', e)
+    // Clean up the client-side subscription so we don't leave a zombie.
+    try { await subscription.unsubscribe() } catch {}
+    return false
+  }
+}
+
+/** Revokes the browser subscription and tells the backend to forget it. */
+export async function disableNotifications(): Promise<boolean> {
+  const reg = await getRegistration()
+  if (!reg) return true   // nothing to do
+
+  const sub = await reg.pushManager.getSubscription()
+  if (!sub) return true
+
+  try {
+    await api.post('/push/unsubscribe', { endpoint: sub.endpoint })
+  } catch (e) {
+    console.warn('[akela] /push/unsubscribe failed (continuing client-side):', e)
+  }
+
+  try {
+    await sub.unsubscribe()
+    return true
+  } catch (e) {
+    console.warn('[akela] browser unsubscribe failed:', e)
+    return false
+  }
+}
+
+export async function sendTestNotification(): Promise<boolean> {
+  try {
+    const r = await api.post('/push/test')
+    return (r.data?.delivered ?? 0) > 0
+  } catch {
+    return false
+  }
+}

--- a/migrations/009_push_subscriptions.sql
+++ b/migrations/009_push_subscriptions.sql
@@ -1,0 +1,19 @@
+-- Migration 009: Web Push subscriptions
+-- Stores PushSubscription objects registered by users' browsers so the
+-- backend can deliver Web Push notifications via pywebpush + VAPID.
+--
+-- Idempotent: safe to run multiple times.
+
+CREATE TABLE IF NOT EXISTS push_subscriptions (
+    id                UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    orchestrator_id   UUID         NOT NULL REFERENCES orchestrators(id) ON DELETE CASCADE,
+    endpoint          TEXT         NOT NULL,
+    p256dh            TEXT         NOT NULL,
+    auth              TEXT         NOT NULL,
+    user_agent        TEXT,
+    created_at        TIMESTAMP    NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_push_endpoint UNIQUE (endpoint)
+);
+
+CREATE INDEX IF NOT EXISTS ix_push_subscriptions_orchestrator_id
+    ON push_subscriptions (orchestrator_id);


### PR DESCRIPTION
## Summary

Turns the Akela dashboard into a Progressive Web App users can install to their phone's home screen, and ships the Web Push infrastructure for sending notifications from the backend. Four bisectable commits, ~1040 lines added, 5 removed, zero modifications to existing models or business logic.

## What lands end-to-end

- **Installable PWA** — open the dashboard on a phone, "Add to Home Screen," launches full-screen with its own icon. Works offline (the app shell loads from cache if you're out of signal; live data fails gracefully).
- **Web Push infrastructure** — backend can deliver notifications via pywebpush + VAPID. Opt-in UI in **Settings → 🔔 Notifications** with Enable / Test / Disable buttons. "Test notification" lets you verify end-to-end without waiting for a real event.
- **Graceful degradation** — all three conditions must hold for notifications to work: (1) browser supports Push API, (2) backend has VAPID keys, (3) user grants permission. Each failure mode has its own explanation in the Settings UI so you know exactly what's wrong.

## Deliberately deferred (scope decision)

**Wiring push to actual events** (task completed, agent offline, message mentions). Reasons:
1. Each event source needs its own decision about when/whether to fire (e.g. do you want a push for every message, or only @mentions?) — better to ship the infra, feel the test button, then wire events with intent.
2. Keeps this PR reviewable at ~1040 lines instead of ~1500.
3. The hook point is one function: `api.services.push.send_to_orchestrator(...)`. A follow-up PR just needs to call it from the right places.

## Commits

### 1. `5d54672` — Installable PWA (frontend only)
- `dashboard/public/manifest.json` — name, start_url `/pack/`, scope `/pack/`, display: standalone, theme/background colors matching the dashboard
- `dashboard/public/app-icon.svg` + `app-icon-maskable.svg` — 512×512 icons with the akela background + wolf emoji. Maskable variant has 20% safe-zone padding for Android's icon masks.
- `dashboard/public/sw.js` — hand-written service worker (no Workbox dep):
  - Cache-first for static assets, network-first for navigations
  - Stays out of `/akela-api/*` — API always hits network
  - Push event handler shows notifications from JSON payload
  - Notificationclick handler focuses existing tab or opens new window
- `dashboard/index.html` — `<link rel="manifest">`, Apple touch icon, theme-color, `apple-mobile-web-app-*` meta tags, `viewport-fit=cover` for iPhone notch
- `dashboard/src/main.tsx` — registers `/pack/sw.js` with scope `/pack/`. Production only (dev mode skips to avoid hot-reload cache pain).
- `dashboard/nginx.conf` — adds `Cache-Control: no-store` for `/sw.js` (so updates propagate immediately) and `Service-Worker-Allowed: /pack/` header

### 2. `7099f59` — Backend push infrastructure
- `api/models/push_subscription.py` — SQLAlchemy model: `orchestrator_id` FK, `endpoint` (unique), `p256dh`, `auth`, optional `user_agent`, `created_at`. Cascade delete on orchestrator removal.
- `migrations/009_push_subscriptions.sql` — idempotent SQL for in-place upgrades (fresh deploys use `create_all_tables()`)
- `api/services/push.py` — `send_to_orchestrator(orchestrator_id, title, body, url, ...)` fans out to every registered device. Auto-prunes 404/410 dead subscriptions. No-op with a warning if VAPID keys aren't configured.
- `api/routers/push.py` — `GET /push/vapid-public-key` (unauthenticated), `POST /push/subscribe`, `POST /push/unsubscribe`, `POST /push/test`, `GET /push/subscriptions`. All write endpoints return 503 if VAPID isn't configured.
- `api/config.py` — `vapid_public_key`, `vapid_private_key`, `vapid_subject` settings
- `api/requirements.txt` — `pywebpush==2.0.0`, `py-vapid==1.9.1`

### 3. `1fc37d4` — Frontend push UI
- `dashboard/src/push.ts` — client-side helper module: `checkSupport`, `getStatus`, `enableNotifications`, `disableNotifications`, `sendTestNotification`. Handles all Push API boilerplate (VAPID key fetch, urlBase64 decode, subscription upsert, cleanup on failure).
- `dashboard/src/pages/Settings.tsx` — new `NotificationSettings` component rendered in a "🔔 Notifications" card between Project Settings and Alpha Credentials. Shows one of five states:
  1. Loading (`Checking browser support…`)
  2. Browser doesn't support Web Push
  3. Server VAPID keys missing
  4. Permission denied
  5. Live control — Enable → Test + Disable flow

### 4. `0986844` — Docs
- `README.md` — new `## PWA & Web Push notifications` section with Install / Enable / iOS caveat instructions
- `README.md` — feature table updated with "Installable PWA" and "Web Push notifications" rows
- `README.md` — config reference table updated with VAPID variables
- `.env.example` — new VAPID block with `vapid --gen` command and clear "leave blank to disable" note

## Deploy after merging

**Step 1 — pull the code:**
```bash
ssh ubuntu@<your-vps>
cd ~/akela-ai
git pull
```

**Step 2 — generate VAPID keys (one time):**
```bash
sudo docker compose -f docker-compose.prod.yml up -d --build api
sudo docker compose -f docker-compose.prod.yml exec api vapid --gen
```
That prints a public key and writes `private_key.pem` to the working directory. Copy both values and delete the `.pem` file from the container.

**Step 3 — put keys in `.env`:**
```bash
nano .env
```
Add:
```
VAPID_PUBLIC_KEY=<urlsafe base64 string>
VAPID_PRIVATE_KEY=<pem contents — literal multiline string>
VAPID_SUBJECT=mailto:your-real-email@example.com
```

**Step 4 — run the migration for existing DBs:**
```bash
sudo docker compose -f docker-compose.prod.yml exec -T postgres \
  psql -U akela -d akela < migrations/009_push_subscriptions.sql
```
(`create_all_tables()` handles fresh DBs automatically — this is only for in-place upgrades.)

**Step 5 — restart everything:**
```bash
sudo docker compose -f docker-compose.prod.yml up -d --build api dashboard
```

**Step 6 — test on your phone:**
1. Open `https://akela-ai.com/pack` in Safari (iOS) or Chrome (Android)
2. iOS: Share → *Add to Home Screen*. Android: menu → *Install app*
3. Open Akela from your home screen
4. Settings → 🔔 Notifications → **Enable notifications** → allow in the permission prompt
5. Click **Send test notification** — it should arrive within a few seconds

## What's NOT in this PR (for clarity)

- No wiring from real events to push delivery yet (deferred — follow-up PR)
- No push preferences ("notify me about X but not Y")
- No notification badge/count
- No custom notification sound
- Desktop notifications on Chrome/Firefox/Edge work the same way as mobile — not tested explicitly but the code doesn't need anything mobile-specific

## Test plan

- [ ] After deploy, open `https://akela-ai.com/pack` in Chrome desktop. DevTools → Application → Manifest should show the parsed manifest. Service Worker should be registered and active.
- [ ] DevTools → Lighthouse → PWA audit: should pass the "Installable" check.
- [ ] Chrome address bar should show an "Install Akela" button.
- [ ] Install Akela on Chrome, launch it, confirm it opens in its own window without browser chrome.
- [ ] Settings → 🔔 Notifications. Before VAPID is configured: "Web Push is not configured on this server" message. After: the Enable button.
- [ ] Enable notifications → Chrome asks permission → allow → status flips to "enabled on this device" with Test + Disable buttons.
- [ ] **Send test notification** → an actual notification appears (system notification on macOS, not an in-tab toast).
- [ ] Click the notification → dashboard tab gets focus (or opens if closed).
- [ ] **Disable** → confirm DevTools → Application → Service Workers → Push shows no active subscription.
- [ ] iOS Safari: open `https://akela-ai.com/pack`, try to enable notifications without installing first — it should fail gracefully. Install to home screen, launch Akela, retry — it should work.
- [ ] Without VAPID keys, verify the Settings section shows the "not configured" message and no button is clickable. Rest of Akela keeps working (dashboard loads, chat works, nothing crashes).