### PR TITLE
fix(push): return ArrayBuffer not Uint8Array to unblock Docker build

### DIFF
--- a/dashboard/src/push.ts
+++ b/dashboard/src/push.ts
@@ -22,13 +22,18 @@ export interface PushStatus {
   subscribed: boolean        // there's an active subscription for this browser
 }
 
-function urlBase64ToUint8Array(base64String: string): Uint8Array {
+function urlBase64ToArrayBuffer(base64String: string): ArrayBuffer {
+  // Returns a plain ArrayBuffer (not a Uint8Array view) so the result is
+  // unambiguously a BufferSource at the TypeScript level. TS 5.7+ narrowed
+  // Uint8Array's backing buffer to ArrayBufferLike (ArrayBuffer | SharedArrayBuffer),
+  // which no longer satisfies pushManager.subscribe's applicationServerKey type.
   const padding = '='.repeat((4 - (base64String.length % 4)) % 4)
   const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/')
   const raw = window.atob(base64)
-  const out = new Uint8Array(raw.length)
-  for (let i = 0; i < raw.length; ++i) out[i] = raw.charCodeAt(i)
-  return out
+  const buffer = new ArrayBuffer(raw.length)
+  const view = new Uint8Array(buffer)
+  for (let i = 0; i < raw.length; ++i) view[i] = raw.charCodeAt(i)
+  return buffer
 }
 
 export function checkSupport(): boolean {
@@ -112,7 +117,7 @@ export async function enableNotifications(): Promise<boolean> {
     const existing = await reg.pushManager.getSubscription()
     subscription = existing || await reg.pushManager.subscribe({
       userVisibleOnly: true,
-      applicationServerKey: urlBase64ToUint8Array(publicKey),
+      applicationServerKey: urlBase64ToArrayBuffer(publicKey),
     })
   } catch (e) {
     console.warn('[akela] push subscribe failed:', e)


### PR DESCRIPTION
## Summary

Follow-up fix to PR #5 — the PWA/Web Push PR merged cleanly but then failed to build inside the Docker image because of a TypeScript 5.7 strict-types issue. One file, 10 insertions, 5 deletions.

## The build error

```
src/push.ts(115,7): error TS2322:
  Type 'Uint8Array<ArrayBufferLike>' is not assignable to type
  'string | BufferSource | null | undefined'.
    Type 'SharedArrayBuffer' is not assignable to type 'ArrayBuffer'.
```

## Why

TypeScript 5.7 widened `Uint8Array`'s type parameter from `ArrayBuffer` to `ArrayBufferLike` (= `ArrayBuffer | SharedArrayBuffer`). The DOM types for `BufferSource` still require specifically `ArrayBuffer`, so passing a `Uint8Array` to `PushManager.subscribe`'s `applicationServerKey` no longer type-checks — even though it works fine at runtime.

The dashboard is on TS 5.9 (`"typescript": "~5.9.3"` in package.json), so this bit us on the fresh Docker build.

## Fix

Renamed `urlBase64ToUint8Array` → `urlBase64ToArrayBuffer` and returns the underlying `ArrayBuffer` directly instead of the `Uint8Array` view wrapping it. `ArrayBuffer` is unambiguously a `BufferSource`, so the call site needs no cast.

**Zero runtime behavior change** — the function was already constructing a `Uint8Array` backed by an `ArrayBuffer`. Now it returns the buffer instead of the view. The `PushManager.subscribe` API accepts both, so the wire format and actual subscription flow are identical.

## Why this is a separate PR

The original TS fix commit was pushed to the already-merged `feat/pwa-and-web-push` branch after PR #5 merged, which was a mistake — pushing to a closed PR's branch doesn't reopen it. This branch cherry-picks that commit onto main so it can ship as a real PR.

## Deploy after merge

```bash
ssh ubuntu@<your-vps>
cd ~/akela-ai
git pull
sudo docker compose -f docker-compose.prod.yml up -d --build dashboard
```

Only the dashboard service needs rebuilding.

## Test plan

- [ ] `npm run build` in `dashboard/` succeeds (the exact check that was failing)
- [ ] `docker compose -f docker-compose.prod.yml build dashboard` succeeds
- [ ] After deploy: open the dashboard, go to Settings → 🔔 Notifications, click **Enable notifications** — the full subscription flow still works (proves the runtime behavior is unchanged)