### PR TITLE
fix: send bearer token when calling agent endpoints

### DIFF
--- a/api/services/a2a_caller.py
+++ b/api/services/a2a_caller.py
@@ -357,12 +357,15 @@ def _extract_tool_call_from_artifact(artifact: dict) -> str:
 _publish_words = BaseAgentCaller.publish_words
 
 
-async def ping_a2a_endpoint(endpoint_url: str) -> bool:
+async def ping_a2a_endpoint(endpoint_url: str, bearer_token: str | None = None) -> bool:
     base = endpoint_url.rstrip("/")
+    headers: dict[str, str] = {}
+    if bearer_token:
+        headers["Authorization"] = f"Bearer {bearer_token}"
     for path in ["/.well-known/agent-card.json", "/.well-known/agent.json"]:
         try:
             async with httpx.AsyncClient(timeout=8.0) as client:
-                resp = await client.get(f"{base}{path}")
+                resp = await client.get(f"{base}{path}", headers=headers)
                 if resp.status_code < 500:
                     return True
         except Exception:

--- a/api/services/endpoint_caller.py
+++ b/api/services/endpoint_caller.py
@@ -133,6 +133,7 @@ async def call_endpoint_streaming(
     history: list[dict] | None = None,
     orchestrator_id: str = "",
     attachments: list[dict] | None = None,
+    bearer_token: str | None = None,
 ) -> tuple[str, dict, str]:
     """
     Call OpenAI-compatible /v1/chat/completions with stream=True.
@@ -179,8 +180,12 @@ async def call_endpoint_streaming(
     # Track announced tool calls by index (standard OpenAI format)
     _announced_tool_idxs: set[int] = set()
 
+    req_headers: dict[str, str] = {"Content-Type": "application/json"}
+    if bearer_token:
+        req_headers["Authorization"] = f"Bearer {bearer_token}"
+
     async with httpx.AsyncClient(timeout=120.0) as client:
-        async with client.stream("POST", url, json=payload, headers={"Content-Type": "application/json"}) as resp:
+        async with client.stream("POST", url, json=payload, headers=req_headers) as resp:
             resp.raise_for_status()
             async for line in resp.aiter_lines():
                 if not line.startswith("data:"):
@@ -414,7 +419,7 @@ async def handle_agent_notify(
             # openai-compatible (Hermes gateway, LiteLLM, etc.)
             full_text, meta, stream_id = await call_endpoint_streaming(
                 agent.endpoint_url, content, agent.name, room, redis_client, history, orchestrator_id,
-                attachments=attachments,
+                attachments=attachments, bearer_token=agent.bearer_token,
             )
     except asyncio.CancelledError:
         logger.info(f"endpoint_caller: streaming cancelled for agent {agent_id} in room {room}")
@@ -529,15 +534,18 @@ async def get_real_model_name(endpoint_url: str) -> str:
     return ""
 
 
-async def ping_endpoint(endpoint_url: str, protocol: AgentProtocol = AgentProtocol.openai) -> bool:
+async def ping_endpoint(endpoint_url: str, protocol: AgentProtocol = AgentProtocol.openai, bearer_token: str | None = None) -> bool:
     """Check if an endpoint is reachable."""
     if protocol == AgentProtocol.a2a:
         from api.services.a2a_caller import ping_a2a_endpoint
-        return await ping_a2a_endpoint(endpoint_url)
+        return await ping_a2a_endpoint(endpoint_url, bearer_token=bearer_token)
     try:
         url = f"{endpoint_url.rstrip('/')}/v1/models"
+        headers: dict[str, str] = {}
+        if bearer_token:
+            headers["Authorization"] = f"Bearer {bearer_token}"
         async with httpx.AsyncClient(timeout=8.0) as client:
-            resp = await client.get(url)
+            resp = await client.get(url, headers=headers)
             return resp.status_code < 500
     except Exception:
         return False
@@ -554,7 +562,7 @@ async def start_health_checker(db_factory, redis_client):
                 for agent in agents:
                     if not agent.endpoint_url or agent.endpoint_url.startswith("fb:"):
                         continue
-                    reachable = await ping_endpoint(agent.endpoint_url, agent.protocol)
+                    reachable = await ping_endpoint(agent.endpoint_url, agent.protocol, bearer_token=agent.bearer_token)
                     new_status = AgentStatus.online if reachable else AgentStatus.offline
                     if agent.status != new_status or (reachable and agent.last_seen_at is None):
                         agent.status = new_status


### PR DESCRIPTION
## Summary

Akela stored the agent's bearer token in the DB but never actually sent it when calling the agent's endpoint. Token-protected agents (like Hermione with `sylang-hermione-key`) got unauthenticated requests, returned 401, and the error was silently swallowed — the Den showed "thinking..." forever with no response.

## Root cause

`endpoint_caller.py` line 183 hard-coded `headers={"Content-Type": "application/json"}` with no `Authorization` header. The `Agent.bearer_token` field existed and the Pack UI let you set it, but the call path never read it.

Verified via curl — agent responds fine with the token:
```
curl ... -H "Authorization: Bearer sylang-hermione-key" → 200 OK, "Hi"
curl ... (no auth header) → 401 Unauthorized
```

## Changes

| What | File |
|---|---|
| OpenAI chat calls send bearer token | `api/services/endpoint_caller.py` — `call_endpoint_streaming()` |
| Health check pings send bearer token | `api/services/endpoint_caller.py` — `ping_endpoint()` + health checker |
| A2A health pings send bearer token | `api/services/a2a_caller.py` — `ping_a2a_endpoint()` |

A2A chat calls (`call_a2a()`) already handled the token correctly. Only the OpenAI chat caller and both ping functions were missing it.

Agents without a bearer token are unaffected — the Authorization header is only added when the token is non-empty.

## Deploy

```bash
cd ~/akela-ai && git pull
sudo docker compose -f docker-compose.prod.yml up -d --build api
```

Only the api service needs rebuilding. After restart, DM Hermione — she should respond.

## Test plan

- [ ] DM Hermione from the Den, send "hi" — response within seconds
- [ ] Hermione shows as **online** in the Pack
- [ ] Agents WITHOUT bearer tokens still work as before