### PR TITLE
feat: browser-direct local agent chat (localhost agents without tunnels)

### DIFF
--- a/api/routers/chat/__init__.py
+++ b/api/routers/chat/__init__.py
@@ -1,10 +1,12 @@
-"""Chat router package — messages, dispatch, and streaming."""
+"""Chat router package — messages, dispatch, streaming, and relay."""
 from fastapi import APIRouter
 from .messages import router as messages_router
 from .dispatch import router as dispatch_router
 from .stream import router as stream_router
+from .relay import router as relay_router
 
 router = APIRouter()
 router.include_router(messages_router)
 router.include_router(dispatch_router)
 router.include_router(stream_router)
+router.include_router(relay_router)

--- a/api/routers/chat/relay.py
+++ b/api/routers/chat/relay.py
@@ -1,0 +1,83 @@
+"""
+Relay endpoint — persists agent responses delivered by the browser.
+
+When an agent runs on the user's local machine, the browser calls the
+agent directly (browser → localhost:8634) instead of going through the
+server-side endpoint_caller. After the browser finishes streaming the
+response, it POSTs the full text here so it's saved in the database and
+shows up in chat history on reload.
+
+This endpoint does NOT publish to Redis pub/sub — the browser already
+rendered the message in the Den. Broadcasting would cause a duplicate
+delivery via SSE to other tabs, but `addMessage` deduplicates by `msg.id`
+so it's harmless if it ever happens. Keeping it clean: relay → save → done.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from typing import Optional
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from api.db.session import get_db
+from api.dependencies import get_current_orchestrator
+from api.models.orchestrator import Orchestrator
+from api.models.agent import Agent
+from api.models.message import Message, MentionType
+from api.schemas.chat import MessageResponse
+
+router = APIRouter(tags=["chat"])
+
+
+class RelayRequest(BaseModel):
+    agent_name: str
+    content: str
+    room: str = "general"
+    msg_metadata: Optional[dict] = None
+
+
+@router.post("/chat/relay", response_model=MessageResponse)
+async def relay_local_agent_message(
+    data: RelayRequest,
+    orch: Orchestrator = Depends(get_current_orchestrator),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Persist a local agent's response.
+
+    Called by the browser after streaming a response directly from a
+    localhost agent. Authenticated via JWT (same as other chat endpoints).
+    """
+    if not data.content.strip():
+        raise HTTPException(status_code=400, detail="Empty content")
+
+    # Try to find the agent by name so we can link agent_id properly.
+    # Tolerate not-found — local-only agents may not be registered on
+    # the server at all.
+    agent_id = None
+    result = await db.execute(
+        select(Agent).where(
+            Agent.orchestrator_id == orch.id,
+            Agent.name == data.agent_name,
+        )
+    )
+    agent = result.scalar_one_or_none()
+    if agent:
+        agent_id = str(agent.id)
+
+    msg = Message(
+        orchestrator_id=orch.id,
+        agent_id=agent_id,
+        sender_name=data.agent_name,
+        sender_role="agent",
+        room=data.room,
+        content=data.content,
+        mentions=[],
+        mention_type=MentionType.normal,
+        msg_metadata=data.msg_metadata,
+    )
+    db.add(msg)
+    await db.commit()
+    await db.refresh(msg)
+
+    return MessageResponse.model_validate(msg)

--- a/dashboard/src/local-chat.ts
+++ b/dashboard/src/local-chat.ts
@@ -1,0 +1,234 @@
+/**
+ * Browser-direct local agent chat.
+ *
+ * When an agent runs on the user's laptop (localhost), the browser calls
+ * its /v1/chat/completions endpoint directly instead of going through the
+ * Akela API server. This module handles:
+ *
+ *   1. Streaming fetch to the local endpoint
+ *   2. SSE line parsing (data: ... / [DONE])
+ *   3. Chunk extraction (content deltas, tool_use, usage)
+ *   4. localStorage persistence for local agent configs
+ *
+ * The remote path (server → endpoint_caller → agent) is completely
+ * untouched. This module is never imported by any server-side code.
+ */
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export interface LocalAgentConfig {
+  localEndpointUrl: string
+  localBearerToken?: string
+}
+
+export interface LocalStreamChunk {
+  type: 'content' | 'tool_use' | 'done'
+  text?: string
+  toolName?: string
+  preview?: string
+  usage?: Record<string, unknown>
+  model?: string
+}
+
+// ── localStorage helpers ─────────────────────────────────────────────
+
+const STORAGE_KEY = 'akela_local_agents'
+
+export function getAllLocalConfigs(): Record<string, LocalAgentConfig> {
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}')
+  } catch {
+    return {}
+  }
+}
+
+export function getLocalConfig(agentName: string): LocalAgentConfig | null {
+  const all = getAllLocalConfigs()
+  return all[agentName] || null
+}
+
+export function setLocalConfig(agentName: string, config: LocalAgentConfig | null): Record<string, LocalAgentConfig> {
+  const all = getAllLocalConfigs()
+  if (config) {
+    all[agentName] = config
+  } else {
+    delete all[agentName]
+  }
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(all))
+  return all
+}
+
+// ── Streaming chat ───────────────────────────────────────────────────
+
+/**
+ * Call a local agent's /v1/chat/completions endpoint with streaming,
+ * yielding parsed chunks as they arrive.
+ *
+ * The caller (Den.tsx) renders each chunk into the streaming message
+ * bubble, then calls /chat/relay to persist the final text.
+ */
+export async function* streamLocalChat(
+  config: LocalAgentConfig,
+  messages: Array<{ role: string; content: string }>,
+  signal?: AbortSignal,
+): AsyncGenerator<LocalStreamChunk, void, void> {
+  const url = `${config.localEndpointUrl.replace(/\/+$/, '')}/v1/chat/completions`
+
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  if (config.localBearerToken) {
+    headers['Authorization'] = `Bearer ${config.localBearerToken}`
+  }
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ messages, stream: true }),
+    signal,
+  })
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => '')
+    throw new Error(`Local agent ${response.status}: ${text.slice(0, 200)}`)
+  }
+
+  const reader = response.body?.getReader()
+  if (!reader) throw new Error('No response body from local agent')
+
+  const decoder = new TextDecoder()
+  let buffer = ''
+  let usage: Record<string, unknown> = {}
+  let model = ''
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+
+      buffer += decoder.decode(value, { stream: true })
+
+      // Process complete lines
+      let newlineIdx = buffer.indexOf('\n')
+      while (newlineIdx >= 0) {
+        const line = buffer.slice(0, newlineIdx).trim()
+        buffer = buffer.slice(newlineIdx + 1)
+
+        if (!line.startsWith('data:')) {
+          newlineIdx = buffer.indexOf('\n')
+          continue
+        }
+
+        const payload = line.slice(5).trim()
+        if (!payload || payload === '[DONE]') {
+          newlineIdx = buffer.indexOf('\n')
+          continue
+        }
+
+        try {
+          const chunk = JSON.parse(payload) as {
+            choices?: Array<{
+              delta?: {
+                content?: string | null
+                tool_use?: { name?: string; preview?: string }
+                tool_calls?: Array<{ function?: { name?: string } }>
+              }
+            }>
+            usage?: Record<string, unknown>
+            model?: string
+          }
+
+          if (chunk.usage) usage = chunk.usage
+          if (chunk.model && !model) model = chunk.model
+
+          const delta = chunk.choices?.[0]?.delta
+          if (!delta) {
+            newlineIdx = buffer.indexOf('\n')
+            continue
+          }
+
+          // Hermes-specific tool_use format
+          if (delta.tool_use) {
+            yield {
+              type: 'tool_use',
+              toolName: delta.tool_use.name || '',
+              preview: delta.tool_use.preview || '',
+            }
+          }
+          // Standard OpenAI tool_calls format
+          else if (delta.tool_calls) {
+            for (const tc of delta.tool_calls) {
+              const name = tc.function?.name
+              if (name) {
+                yield { type: 'tool_use', toolName: name, preview: '' }
+              }
+            }
+          }
+          // Content chunk
+          else if (delta.content) {
+            yield { type: 'content', text: delta.content }
+          }
+        } catch {
+          // Skip malformed JSON chunks
+        }
+
+        newlineIdx = buffer.indexOf('\n')
+      }
+    }
+  } finally {
+    reader.releaseLock()
+  }
+
+  // Final chunk with accumulated usage stats
+  yield { type: 'done', usage, model }
+}
+
+// ── History builder (mirrors server-side build_history) ──────────────
+
+/**
+ * Build an OpenAI-compatible message history from the current room's
+ * messages. Mirrors the server-side build_history logic:
+ *
+ *   - Alpha messages → user role
+ *   - This agent's messages → assistant role
+ *   - Other agents → skipped (private bubble model)
+ *   - Consecutive same-role turns merged by concatenation
+ *   - Leading assistant turns dropped
+ *   - Limited to last N messages
+ */
+export function buildLocalHistory(
+  messages: Array<{ sender_role: string; sender_name: string; content: string }>,
+  agentName: string,
+  limit = 6,
+): Array<{ role: string; content: string }> {
+  // Take the last `limit` raw messages from the room
+  const recent = messages.slice(-limit)
+
+  const raw: Array<{ role: string; content: string }> = []
+  for (const m of recent) {
+    const content = (m.content || '').trim()
+    if (!content) continue
+
+    if (m.sender_role === 'alpha') {
+      raw.push({ role: 'user', content })
+    } else if (m.sender_role === 'agent' && m.sender_name === agentName) {
+      raw.push({ role: 'assistant', content })
+    }
+    // Other agents and system messages: skipped (private bubble)
+  }
+
+  // Merge consecutive same-role turns
+  const history: Array<{ role: string; content: string }> = []
+  for (const turn of raw) {
+    if (history.length > 0 && history[history.length - 1].role === turn.role) {
+      history[history.length - 1].content += '\n\n' + turn.content
+    } else {
+      history.push({ ...turn })
+    }
+  }
+
+  // Drop leading assistant turns
+  while (history.length > 0 && history[0].role === 'assistant') {
+    history.shift()
+  }
+
+  return history
+}

--- a/dashboard/src/pages/AgentChat.tsx
+++ b/dashboard/src/pages/AgentChat.tsx
@@ -7,6 +7,7 @@ import { ArrowLeft, Bot } from 'lucide-react'
 import { MessageContent } from '../components/MessageContent'
 import { MessageActions } from '../components/MessageActions'
 import { ChatInput } from '../components/ChatInput'
+import { streamLocalChat, buildLocalHistory } from '../local-chat'
 
 const API_BASE = import.meta.env.DEV ? 'http://localhost:8200' : '/akela-api'
 
@@ -137,7 +138,7 @@ function DMBubble({
 export function AgentChat() {
   const { agentName } = useParams<{ agentName: string }>()
   const navigate = useNavigate()
-  const { token, agents, clearUnread } = useStore()
+  const { token, agents, clearUnread, localAgentConfigs } = useStore()
   const [messages, setMessages] = useState<Message[]>([])
   const [sending, setSending] = useState(false)
   const [typing, setTyping] = useState(false)
@@ -151,6 +152,8 @@ export function AgentChat() {
 
   const agent = agents.find(a => a.name === agentName)
   const room = `dm:${agentName}`
+  const localConfig = agentName ? localAgentConfigs[agentName] : null
+  const localAbortRef = useRef<AbortController | null>(null)
 
   // Reset ALL state when switching between agents
   useEffect(() => {
@@ -241,6 +244,7 @@ export function AgentChat() {
     setLastUserMessage(text.trim())
     setLastStats(null)
     try {
+      // Persist user message via server (unchanged — also dispatches to remote agents)
       await api.post('/chat/messages/alpha', {
         content: text.trim(),
         room,
@@ -251,6 +255,98 @@ export function AgentChat() {
       console.error('Send failed:', e)
     }
     setSending(false)
+
+    // If this DM target has a local config, call it directly from the browser
+    if (localConfig && agentName) {
+      handleLocalDM(text.trim())
+    }
+  }
+
+  /** Stream a response from a local agent in a DM. */
+  const handleLocalDM = async (content: string) => {
+    if (!localConfig || !agentName) return
+    const abortController = new AbortController()
+    localAbortRef.current = abortController
+
+    setTyping(true)
+    const history = buildLocalHistory(messages, agentName, 6)
+    const allMessages = [...history, { role: 'user', content }]
+
+    let fullText = ''
+    let usage: Record<string, unknown> = {}
+    let model = ''
+    const startTs = Date.now()
+
+    try {
+      for await (const chunk of streamLocalChat(localConfig, allMessages, abortController.signal)) {
+        if (chunk.type === 'content' && chunk.text) {
+          fullText += chunk.text
+          setStreamingText(fullText)
+          setIsStreaming(true)
+          setTyping(false)
+        } else if (chunk.type === 'tool_use' && chunk.toolName) {
+          setToolSteps(prev => [...prev, { tool_name: chunk.toolName!, preview: chunk.preview || '' }])
+        } else if (chunk.type === 'done') {
+          usage = chunk.usage || {}
+          model = chunk.model || ''
+        }
+      }
+    } catch (err) {
+      if ((err as Error).name !== 'AbortError') {
+        console.error(`[local-dm] ${agentName} error:`, err)
+      }
+      setIsStreaming(false)
+      setStreamingText('')
+      setTyping(false)
+      localAbortRef.current = null
+      return
+    }
+
+    localAbortRef.current = null
+    setIsStreaming(false)
+    setStreamingText('')
+    setTyping(false)
+
+    if (!fullText.trim()) return
+
+    const durationMs = Date.now() - startTs
+    const completionTokens = (usage as { completion_tokens?: number }).completion_tokens || 0
+    const tokensPerSec = completionTokens > 0 && durationMs > 0
+      ? Math.round(completionTokens / (durationMs / 1000) * 10) / 10 : 0
+    setLastStats({ usage: usage as any, durationMs, tokensPerSec })
+
+    const meta = { usage: { ...usage, model }, duration_ms: durationMs, tokens_per_sec: tokensPerSec, model }
+
+    // Relay to server for persistence
+    try {
+      const relayRes = await api.post('/chat/relay', {
+        agent_name: agentName,
+        content: fullText,
+        room,
+        msg_metadata: meta,
+      })
+      if (relayRes.data?.id) {
+        setMessages(prev => {
+          if (prev.some(m => m.id === relayRes.data.id)) return prev
+          return [...prev, relayRes.data as Message]
+        })
+      }
+    } catch (e) {
+      console.error('[local-dm] relay failed:', e)
+      setMessages(prev => [...prev, {
+        id: crypto.randomUUID(),
+        sender_name: agentName,
+        sender_role: 'agent',
+        content: fullText,
+        room,
+        mentions: [],
+        mention_type: 'normal',
+        created_at: new Date().toISOString(),
+        msg_metadata: meta,
+      } as Message])
+    }
+
+    setToolSteps([])
   }
 
   const handleRegenerate = async () => {
@@ -264,6 +360,9 @@ export function AgentChat() {
       setTyping(true)
     } catch (e) {
       console.error('Regenerate failed:', e)
+    }
+    if (localConfig && agentName) {
+      handleLocalDM(lastUserMessage)
     }
   }
 
@@ -433,6 +532,10 @@ export function AgentChat() {
         onStop={async () => {
           try {
             await api.post('/chat/stop', { room })
+            if (localAbortRef.current) {
+              localAbortRef.current.abort()
+              localAbortRef.current = null
+            }
             setTyping(false)
             setIsStreaming(false)
             setStreamingText('')

--- a/dashboard/src/pages/Den.tsx
+++ b/dashboard/src/pages/Den.tsx
@@ -6,6 +6,7 @@ import { Radio, AtSign, Plus, Folder, Trash2, GripVertical, MessageSquare, Folde
 import { MessageContent } from '../components/MessageContent'
 import { MessageActions } from '../components/MessageActions'
 import { ChatInput } from '../components/ChatInput'
+import { streamLocalChat, buildLocalHistory } from '../local-chat'
 
 const API_BASE = import.meta.env.DEV ? 'http://localhost:8200' : '/akela-api'
 
@@ -500,6 +501,7 @@ export function Den() {
   const {
     messages, setMessages, addMessage, activeRoom, setActiveRoom,
     activeConversation, agents, activeProject, notifyTaskUpdate,
+    localAgentConfigs,
   } = useStore()
 
   // Switch room when project changes
@@ -530,6 +532,8 @@ export function Den() {
   const bottomRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLTextAreaElement>(null)
   const typingTimeouts = useRef<Record<string, ReturnType<typeof setTimeout>>>({})
+  // Abort controllers for in-flight local agent streams (keyed by agent name)
+  const localAbortRef = useRef<Record<string, AbortController>>({})
 
   // Hunt autocomplete data — fetched from DB when project changes
   const [huntEpics, setHuntEpics] = useState<{id: string, title: string}[]>([])
@@ -807,6 +811,8 @@ export function Den() {
     setLastUserInput(content)
     setLastDenStats(null)
     try {
+      // Persist the user message via the server (unchanged — remote agents
+      // are dispatched by the server-side endpoint_caller through this path)
       await api.post('/chat/messages/alpha', {
         room: activeRoom,
         content,
@@ -814,6 +820,149 @@ export function Den() {
       })
     } catch (e) {
       console.error(e)
+    }
+
+    // ── Local agent dispatch (browser-direct) ─────────────────────────
+    // Parse @mentions from content and call local agents directly.
+    // This runs IN ADDITION TO the server post — remote agents are still
+    // dispatched by the server. Local agents (which the server can't
+    // reach) are called from the browser.
+    const mentionMatches = content.match(/@([\w-]+)/g) || []
+    const mentionedNames = mentionMatches.map(m => m.slice(1))
+
+    let localTargets: string[] = []
+    if (mentionedNames.includes('all')) {
+      // @all broadcast — call every agent that has a local config
+      localTargets = agents
+        .filter(a => localAgentConfigs[a.name])
+        .map(a => a.name)
+    } else {
+      // Specific mentions — call only the ones with local configs
+      localTargets = mentionedNames.filter(name => localAgentConfigs[name])
+    }
+
+    for (const agentName of localTargets) {
+      handleLocalAgentChat(agentName, content, activeRoom)
+    }
+  }
+
+  /** Stream a response from a local agent running on the user's device. */
+  const handleLocalAgentChat = async (agentName: string, content: string, room: string) => {
+    const config = localAgentConfigs[agentName]
+    if (!config) return
+
+    const streamId = crypto.randomUUID().slice(0, 8)
+    const startTs = Date.now()
+    const abortController = new AbortController()
+    localAbortRef.current[agentName] = abortController
+
+    // Show typing indicator
+    setTypingAgents(prev => [...new Set([...prev, agentName])])
+
+    // Build history from current messages (same logic as server-side build_history)
+    const history = buildLocalHistory(messages, agentName, 6)
+    const allMessages = [...history, { role: 'user', content }]
+
+    let fullText = ''
+    let usage: Record<string, unknown> = {}
+    let model = ''
+    const toolCalls: { name: string; preview: string }[] = []
+
+    try {
+      for await (const chunk of streamLocalChat(config, allMessages, abortController.signal)) {
+        if (chunk.type === 'content' && chunk.text) {
+          fullText += chunk.text
+          setStreamingMessages(prev => ({
+            ...prev,
+            [streamId]: { sender_name: agentName, full_text: fullText },
+          }))
+          setTypingAgents(prev => prev.filter(n => n !== agentName))
+        } else if (chunk.type === 'tool_use' && chunk.toolName) {
+          toolCalls.push({ name: chunk.toolName, preview: chunk.preview || '' })
+          setActiveToolSteps(prev => ({
+            ...prev,
+            [agentName]: [...(prev[agentName] || []), {
+              stream_id: streamId,
+              sender_name: agentName,
+              tool_name: chunk.toolName!,
+              preview: chunk.preview || '',
+            }],
+          }))
+        } else if (chunk.type === 'done') {
+          usage = chunk.usage || {}
+          model = chunk.model || ''
+        }
+      }
+    } catch (err) {
+      if ((err as Error).name === 'AbortError') {
+        // User clicked Stop — clean up silently
+      } else {
+        console.error(`[local-agent] ${agentName} error:`, err)
+      }
+      setStreamingMessages(prev => { const n = { ...prev }; delete n[streamId]; return n })
+      setTypingAgents(prev => prev.filter(n => n !== agentName))
+      delete localAbortRef.current[agentName]
+      return
+    }
+
+    delete localAbortRef.current[agentName]
+
+    // Clear streaming state
+    setStreamingMessages(prev => { const n = { ...prev }; delete n[streamId]; return n })
+    setTypingAgents(prev => prev.filter(n => n !== agentName))
+
+    if (!fullText.trim()) return
+
+    // Compute stats
+    const durationMs = Date.now() - startTs
+    const completionTokens = (usage as { completion_tokens?: number }).completion_tokens || 0
+    const tokensPerSec = completionTokens > 0 && durationMs > 0
+      ? Math.round(completionTokens / (durationMs / 1000) * 10) / 10
+      : 0
+
+    setLastDenStats({ usage: usage as any, durationMs, tokensPerSec })
+
+    // Build metadata matching the format endpoint_caller produces
+    const meta = {
+      usage: { ...usage, model },
+      duration_ms: durationMs,
+      tokens_per_sec: tokensPerSec,
+      model,
+      tool_calls: toolCalls,
+    }
+
+    // Relay to server for persistence
+    try {
+      const relayRes = await api.post('/chat/relay', {
+        agent_name: agentName,
+        content: fullText,
+        room,
+        msg_metadata: meta,
+      })
+      if (relayRes.data?.id) {
+        // Transfer tool steps from the agent key to the message id
+        setActiveToolSteps(prev => {
+          if (prev[agentName]?.length) {
+            setMessageToolSteps(ms => ({ ...ms, [relayRes.data.id]: prev[agentName] }))
+          }
+          const next = { ...prev }; delete next[agentName]; return next
+        })
+        addMessage(relayRes.data as Message)
+      }
+    } catch (e) {
+      console.error('[local-agent] relay failed, adding message locally:', e)
+      // Still show the message even if relay fails (offline resilience)
+      addMessage({
+        id: streamId,
+        sender_name: agentName,
+        sender_role: 'agent',
+        content: fullText,
+        room,
+        mentions: [],
+        mention_type: 'normal',
+        created_at: new Date().toISOString(),
+        msg_metadata: meta,
+      } as Message)
     }
   }
 
@@ -824,6 +973,18 @@ export function Den() {
       await api.post('/chat/messages/alpha', { room: activeRoom, content: lastUserInput })
     } catch (e) {
       console.error(e)
+    }
+    // Also re-trigger local agents if any were mentioned
+    const mentionMatches = lastUserInput.match(/@([\w-]+)/g) || []
+    const mentionedNames = mentionMatches.map(m => m.slice(1))
+    let localTargets: string[] = []
+    if (mentionedNames.includes('all')) {
+      localTargets = agents.filter(a => localAgentConfigs[a.name]).map(a => a.name)
+    } else {
+      localTargets = mentionedNames.filter(name => localAgentConfigs[name])
+    }
+    for (const agentName of localTargets) {
+      handleLocalAgentChat(agentName, lastUserInput, activeRoom)
     }
   }
 
@@ -1126,7 +1287,11 @@ export function Den() {
               isActive={typingAgents.length > 0 || Object.keys(streamingMessages).length > 0}
               onStop={async () => {
                 try {
+                  // Stop remote agents via server
                   await api.post('/chat/stop', { room: activeRoom })
+                  // Abort any in-flight local agent streams
+                  Object.values(localAbortRef.current).forEach(c => c.abort())
+                  localAbortRef.current = {}
                   setTypingAgents([])
                   setStreamingMessages({})
                 } catch (e) { console.error('Stop failed:', e) }

--- a/dashboard/src/pages/Pack.tsx
+++ b/dashboard/src/pages/Pack.tsx
@@ -23,6 +23,7 @@ const inputStyle = {
 function AgentCard({ agent, onDelete, onUpdate, readOnly = false }: {
   agent: Agent, onDelete: (id: string) => void, onUpdate: () => void, readOnly?: boolean
 }) {
+  const { localAgentConfigs, setLocalAgentConfig } = useStore()
   const isOnline = agent.status === 'online'
   const rank = agent.rank
   const color = rankColors[rank] || 'var(--text-secondary)'
@@ -37,6 +38,10 @@ function AgentCard({ agent, onDelete, onUpdate, readOnly = false }: {
   const [editWorkspaceUrl, setEditWorkspaceUrl] = useState((agent.soul as any)?.workspace_url || '')
   const [discovering, setDiscovering] = useState(false)
   const [saving, setSaving] = useState(false)
+  // Local agent config (browser-direct, stored in localStorage)
+  const existingLocal = localAgentConfigs[agent.name]
+  const [editLocalUrl, setEditLocalUrl] = useState(existingLocal?.localEndpointUrl || '')
+  const [editLocalToken, setEditLocalToken] = useState(existingLocal?.localBearerToken || '')
 
   const handleDiscover = async () => {
     if (!editEndpoint.trim()) return
@@ -74,6 +79,15 @@ function AgentCard({ agent, onDelete, onUpdate, readOnly = false }: {
           a2a_streaming: editProtocol === 'a2a' ? true : undefined,
         },
       })
+      // Save local agent config (client-side only — not sent to server)
+      if (editLocalUrl.trim()) {
+        setLocalAgentConfig(agent.name, {
+          localEndpointUrl: editLocalUrl.trim(),
+          localBearerToken: editLocalToken.trim() || undefined,
+        })
+      } else {
+        setLocalAgentConfig(agent.name, null)
+      }
       setEditing(false)
       onUpdate()
     } catch (e: any) {
@@ -176,6 +190,28 @@ function AgentCard({ agent, onDelete, onUpdate, readOnly = false }: {
         </div>
       )}
 
+      {/* Local agent badge (read-only view) */}
+      {!editing && existingLocal && (
+        <div style={{ marginBottom: 12 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 }}>
+            <div style={{ fontSize: 11, color: 'var(--text-muted)', fontWeight: 600 }}>LOCAL ENDPOINT</div>
+            <span style={{
+              fontSize: 10, fontWeight: 700, padding: '1px 6px', borderRadius: 8,
+              background: 'rgba(250,204,21,0.15)', color: '#facc15',
+              border: '1px solid rgba(250,204,21,0.3)',
+            }}>LOCAL</span>
+          </div>
+          <code style={{
+            fontSize: 11, color: '#facc15', background: 'var(--bg-elevated)',
+            padding: '4px 8px', borderRadius: 4, display: 'block',
+            border: '1px solid var(--border)', wordBreak: 'break-all',
+          }}>{existingLocal.localEndpointUrl}</code>
+          <div style={{ fontSize: 10, color: 'var(--text-muted)', marginTop: 4, fontStyle: 'italic' }}>
+            Browser-direct — your device only
+          </div>
+        </div>
+      )}
+
       {/* Edit panel */}
       {editing && (
         <div style={{ marginTop: 8 }}>
@@ -242,7 +278,36 @@ function AgentCard({ agent, onDelete, onUpdate, readOnly = false }: {
             )}
           </div>
 
-          <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+          {/* ── Local Agent (browser-direct) ────────────────────────── */}
+          <div style={{
+            marginTop: 12, padding: 12, borderRadius: 8,
+            background: 'rgba(250,204,21,0.04)',
+            border: '1px solid rgba(250,204,21,0.15)',
+          }}>
+            <div style={{ fontSize: 10, fontWeight: 700, color: '#facc15', letterSpacing: '0.06em', marginBottom: 8 }}>
+              LOCAL AGENT (BROWSER-DIRECT)
+            </div>
+            <div style={{ fontSize: 11, color: 'var(--text-muted)', marginBottom: 10, lineHeight: 1.5 }}>
+              Runs on <strong style={{ color: 'var(--text-primary)' }}>your device</strong>. The server cannot reach it — your browser calls it directly. Leave blank if this is a remote agent.
+            </div>
+            <div className="form-row-stack" style={{ display: 'flex', gap: 8, marginBottom: 4 }}>
+              <div style={{ flex: 2 }}>
+                <div style={{ fontSize: 10, color: 'var(--text-muted)', marginBottom: 4 }}>LOCAL ENDPOINT URL</div>
+                <input value={editLocalUrl} onChange={e => setEditLocalUrl(e.target.value)} placeholder="http://localhost:8634" style={inputStyle} />
+              </div>
+              <div style={{ flex: 1 }}>
+                <div style={{ fontSize: 10, color: 'var(--text-muted)', marginBottom: 4 }}>LOCAL BEARER TOKEN</div>
+                <input value={editLocalToken} onChange={e => setEditLocalToken(e.target.value)} placeholder="Optional" type="password" style={inputStyle} />
+              </div>
+            </div>
+            {editLocalUrl.trim() && editEndpoint.trim() && (
+              <div style={{ fontSize: 10, color: '#facc15', marginTop: 6, lineHeight: 1.5 }}>
+                ⚠ Both a server endpoint and a local URL are set. When you @mention this agent, <strong>both</strong> the server and your browser will call it — you may get double responses. Clear the server endpoint if this agent only runs locally.
+              </div>
+            )}
+          </div>
+
+          <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginTop: 12 }}>
             <button onClick={handleSave} disabled={saving} style={{
               padding: '6px 16px', background: 'var(--accent)', border: 'none', borderRadius: 6,
               color: 'white', fontSize: 12, fontWeight: 600, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 4,

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -98,6 +98,11 @@ interface Stats {
   done_tasks: number
 }
 
+export interface LocalAgentConfig {
+  localEndpointUrl: string
+  localBearerToken?: string
+}
+
 interface Store {
   user: User | null
   token: string | null
@@ -129,6 +134,9 @@ interface Store {
   clearUnread: (agentName: string) => void
   lastTaskUpdate: number
   notifyTaskUpdate: () => void
+  // Local agent configs — browser-direct endpoints stored in localStorage
+  localAgentConfigs: Record<string, LocalAgentConfig>
+  setLocalAgentConfig: (agentName: string, config: LocalAgentConfig | null) => void
 }
 
 export const useStore = create<Store>((set) => ({
@@ -179,5 +187,18 @@ export const useStore = create<Store>((set) => ({
   }),
   lastTaskUpdate: 0,
   notifyTaskUpdate: () => set({ lastTaskUpdate: Date.now() }),
+  // Local agent configs — persisted in localStorage, never sent to the server.
+  // The server can't reach localhost endpoints anyway; this is client-only state.
+  localAgentConfigs: JSON.parse(localStorage.getItem('akela_local_agents') || '{}'),
+  setLocalAgentConfig: (agentName, config) => set((s) => {
+    const next = { ...s.localAgentConfigs }
+    if (config) {
+      next[agentName] = config
+    } else {
+      delete next[agentName]
+    }
+    localStorage.setItem('akela_local_agents', JSON.stringify(next))
+    return { localAgentConfigs: next }
+  }),
 }))
 


### PR DESCRIPTION
## Summary

Enables agents running on your local machine (localhost) to work with the Akela dashboard without SSH tunnels, ngrok, or any port forwarding. The browser calls the local agent directly — same pattern used in the sylang-hermes project's local-file-ops.

**5 bisectable commits, +676 lines, -3 lines, 7 files touched.** Zero modifications to the existing remote agent path.

## How it works

```
REMOTE AGENT (unchanged):
  Den → POST /chat/messages → server → endpoint_caller → remote agent → Redis SSE → Den

LOCAL AGENT (new):
  Den → POST /chat/messages (persists user msg)
      → browser detects @mentioned agent has localConfig
      → browser fetch() → localhost:8634/v1/chat/completions
      → browser renders SSE chunks in the Den
      → browser POST /chat/relay → server persists agent response
```

Both paths can coexist in the same room. @mention a remote agent and a local agent in the same message — the server dispatches to the remote one, the browser dispatches to the local one, both responses appear in the Den.

## User flow

1. **The Pack → edit an agent card** → new "LOCAL AGENT (BROWSER-DIRECT)" section at the bottom of the edit form
2. Enter `http://localhost:8634` (or whatever port your Hermes runs on) + optional bearer token
3. Save → a yellow "LOCAL" badge appears on the card
4. **The Den → @mention that agent** → browser calls localhost directly, streams the response, saves it to the DB

## Commits

### 1. `3a2548f` — Backend relay endpoint
- `api/routers/chat/relay.py` — `POST /chat/relay` accepts `{ agent_name, content, room, msg_metadata }`, saves to Message table, returns MessageResponse. JWT-authenticated. Does NOT publish to Redis (browser already rendered it). Looks up Agent by name for agent_id linkage, tolerates not-found.

### 2. `ae390d5` — Client-side streaming helper + store
- `dashboard/src/local-chat.ts` — `streamLocalChat()` async generator (browser fetch → SSE parsing → typed chunks), `buildLocalHistory()` (mirrors server-side build_history logic), localStorage CRUD for local agent configs.
- `dashboard/src/store.ts` — `localAgentConfigs` state field + `setLocalAgentConfig` action, hydrated from localStorage.

### 3. `62b6ae2` — Den.tsx local agent integration
- After existing `api.post('/chat/messages/alpha')` (UNCHANGED), parses @mentions from content, checks each against `localAgentConfigs`, calls `handleLocalAgentChat()` for each local agent.
- `handleLocalAgentChat()`: builds history, streams via `streamLocalChat()`, renders chunks (typing indicator, tool steps, streaming text), relays final response to `/chat/relay`.
- Stop button aborts local streams via AbortController.
- Regenerate also re-triggers local agents.

### 4. `c3f6a2f` — Pack.tsx local agent config UI
- New "LOCAL AGENT (BROWSER-DIRECT)" section in agent card edit form with endpoint URL + bearer token inputs.
- Yellow warning when both server endpoint and local URL are set (double-response risk).
- "LOCAL" badge in read-only view.
- Save writes to localStorage via `setLocalAgentConfig()`, not to the server.

### 5. `40473a3` — AgentChat.tsx DM local agent support
- Same pattern applied to DM conversations. Simpler: single target agent from URL param, no mention parsing.

## Separation guarantees

- The `api.post('/chat/messages/alpha')` call is UNTOUCHED in both Den.tsx and AgentChat.tsx
- `endpoint_caller.py` is UNTOUCHED — zero changes to the server-side dispatch pipeline
- Redis pub/sub is UNTOUCHED — SSE continues to work for remote agents
- If an agent has no `localAgentConfigs` entry, none of the new code paths execute
- Local config is stored in browser localStorage only — never sent to the server, never persisted in Postgres. The VPS has no use for a localhost URL.

## CORS requirement

The local Hermes agent must allow cross-origin requests from the Akela dashboard domain. Hermes defaults to `Access-Control-Allow-Origin: *` which works. If your local agent has CORS locked down, browser-direct calls will fail with a network error.

## Double-response prevention

If an agent has BOTH a server-side `endpoint_url` AND a `localEndpointUrl`, both the server and the browser will call it. The Pack UI shows a yellow warning about this. To avoid double responses:
- **Local-only agent**: clear the server endpoint, keep only the local URL
- **Remote-only agent**: don't set a local URL
- **Hybrid (testing)**: accept the double response, both appear in the Den

## Deploy

```bash
cd ~/akela-ai && git pull
sudo docker compose -f docker-compose.prod.yml up -d --build api dashboard
```

Both api (relay endpoint) and dashboard (UI changes) need rebuilding.

## Test plan

- [ ] Add an agent in the Pack, set LOCAL ENDPOINT URL to a running local Hermes (e.g. `http://localhost:8634`)
- [ ] Go to the Den, @mention that agent — response should stream from your local machine
- [ ] Open a DM with the same agent — response should stream from localhost
- [ ] The "LOCAL" badge appears on the agent card in read-only view
- [ ] Set both server endpoint + local URL → yellow warning appears in edit form
- [ ] Clear the local URL, save → badge disappears, agent reverts to remote-only
- [ ] Remote agents (no local config) continue to work identically to before
- [ ] Stop button aborts both remote and local streams
- [ ] Close the browser, reopen → local config is still there (persisted in localStorage)
- [ ] Refresh the page → chat history includes the locally-streamed messages (they were relayed to the server)