### PR TITLE
fix: allow agent deletion when assigned to hunt tasks (SET NULL)

### DIFF
--- a/api/models/hunt.py
+++ b/api/models/hunt.py
@@ -93,7 +93,9 @@ class HuntTask(Base):
     epic_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("hunt_epics.id"), nullable=False)
     story_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("hunt_stories.id"), nullable=True)
     sprint_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("hunt_sprints.id"), nullable=True)
-    assignee_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("agents.id"), nullable=True)
+    # SET NULL on agent delete: preserves task history (title, status, comments)
+    # and marks it as unassigned instead of blocking the agent's deletion.
+    assignee_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("agents.id", ondelete="SET NULL"), nullable=True)
     title: Mapped[str] = mapped_column(String, nullable=False)
     description: Mapped[str] = mapped_column(Text, default="", server_default="")
     status: Mapped[str] = mapped_column(String, default="todo")
@@ -118,7 +120,8 @@ class Subtask(Base):
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     task_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("hunt_tasks.id"), nullable=False)
-    assignee_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("agents.id"), nullable=True)
+    # SET NULL on agent delete — same rationale as HuntTask.assignee_id.
+    assignee_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("agents.id", ondelete="SET NULL"), nullable=True)
     title: Mapped[str] = mapped_column(String, nullable=False)
     description: Mapped[str] = mapped_column(Text, default="", server_default="")
     status: Mapped[str] = mapped_column(String, default="todo")

--- a/migrations/010_agent_assignee_set_null.sql
+++ b/migrations/010_agent_assignee_set_null.sql
@@ -1,0 +1,53 @@
+-- Migration 010: Agents can be deleted even when assigned to hunt tasks.
+--
+-- Problem: DELETE /agents/{id} returned 500 because hunt_tasks.assignee_id
+-- and hunt_subtasks.assignee_id had default FK constraints (no ON DELETE
+-- action). Postgres rejected the delete to preserve referential integrity.
+--
+-- Fix: switch the constraints to ON DELETE SET NULL. Deleting an agent now
+-- marks their tasks as "unassigned" (assignee_id → NULL) instead of
+-- blocking the delete. Task history, titles, status, comments — all
+-- preserved. Clean delete without losing project data.
+--
+-- Idempotent: uses DO blocks that check for constraint existence before
+-- dropping, so running this migration twice is safe.
+
+DO $$
+DECLARE
+    constraint_name text;
+BEGIN
+    -- hunt_tasks.assignee_id → agents.id
+    SELECT conname INTO constraint_name
+    FROM pg_constraint
+    WHERE conrelid = 'hunt_tasks'::regclass
+      AND contype = 'f'
+      AND conkey = ARRAY[
+        (SELECT attnum FROM pg_attribute WHERE attrelid = 'hunt_tasks'::regclass AND attname = 'assignee_id')
+      ];
+    IF constraint_name IS NOT NULL THEN
+        EXECUTE format('ALTER TABLE hunt_tasks DROP CONSTRAINT %I', constraint_name);
+    END IF;
+    ALTER TABLE hunt_tasks
+        ADD CONSTRAINT hunt_tasks_assignee_id_fkey
+        FOREIGN KEY (assignee_id) REFERENCES agents(id) ON DELETE SET NULL;
+END $$;
+
+DO $$
+DECLARE
+    constraint_name text;
+BEGIN
+    -- hunt_subtasks.assignee_id → agents.id
+    SELECT conname INTO constraint_name
+    FROM pg_constraint
+    WHERE conrelid = 'hunt_subtasks'::regclass
+      AND contype = 'f'
+      AND conkey = ARRAY[
+        (SELECT attnum FROM pg_attribute WHERE attrelid = 'hunt_subtasks'::regclass AND attname = 'assignee_id')
+      ];
+    IF constraint_name IS NOT NULL THEN
+        EXECUTE format('ALTER TABLE hunt_subtasks DROP CONSTRAINT %I', constraint_name);
+    END IF;
+    ALTER TABLE hunt_subtasks
+        ADD CONSTRAINT hunt_subtasks_assignee_id_fkey
+        FOREIGN KEY (assignee_id) REFERENCES agents(id) ON DELETE SET NULL;
+END $$;


### PR DESCRIPTION
## Summary

\`DELETE /akela-api/agents/{id}\` returned **500 Internal Server Error** when the agent had ever been assigned a hunt task. The Postgres FK constraint blocked the delete to preserve referential integrity.

## Root cause

\`hunt_tasks.assignee_id\` and \`hunt_subtasks.assignee_id\` had default FK constraints — even though they're nullable, the default \`NO ACTION\` prevents deleting the parent agent while child rows reference it.

Other agent-referencing tables already handle delete correctly:
- \`trust_events\`, \`agent_trust_scores\`: ORM cascade via \`relationship(..., cascade='all, delete-orphan')\` on the Agent model
- \`project_agents.agent_id\`: already has \`ON DELETE CASCADE\`

So the 500 was specifically from the two Hunt FKs.

## Fix — Option A (preserve history, clear assignments)

Change both assignee FKs to \`ON DELETE SET NULL\`:
- Agent gets deleted cleanly
- Tasks they were assigned to stay — marked "Unassigned"
- Task titles, descriptions, status, comments, priority, sprint, epic, story relationships all preserved
- Hunt board keeps working

Alternatives considered:
- \`ON DELETE CASCADE\` — would wipe every task the agent ever touched. Too aggressive for a pack where agents come and go.
- Pre-delete cleanup in the route handler — brittle, DB-level enforcement is the right place.

## Changes

| File | What |
|---|---|
| \`api/models/hunt.py\` | Added \`ondelete='SET NULL'\` to \`HuntTask.assignee_id\` and \`Subtask.assignee_id\` |
| \`migrations/010_agent_assignee_set_null.sql\` | Idempotent SQL migration for existing deployments — drops existing FK constraints (looked up by name), recreates with \`ON DELETE SET NULL\` |

The migration uses \`DO\` blocks to look up the current constraint names dynamically — SQLAlchemy's auto-generated FK names vary slightly depending on version, so we don't hard-code them.

## Deploy

\`\`\`bash
cd ~/akela-ai && git pull

# Run the migration on existing database
sudo docker compose -f docker-compose.prod.yml exec -T postgres \\
  psql -U akela -d akela < migrations/010_agent_assignee_set_null.sql

# Restart the API to pick up the new model
sudo docker compose -f docker-compose.prod.yml up -d --build api
\`\`\`

Fresh deployments don't need the migration — \`create_all_tables()\` uses the updated model definitions.

## Test plan

- [ ] After deploy, delete an agent that was never assigned a task → 200 OK (regression check — this already worked)
- [ ] Delete an agent that has one or more assigned hunt tasks → 200 OK (the fix)
- [ ] Reload the Hunt board → the agent's old tasks appear as "Unassigned" instead of breaking
- [ ] Delete an agent with subtasks → 200 OK, subtasks become unassigned
- [ ] Agent's trust score history: should be deleted via ORM cascade (existing behavior)
- [ ] Re-run the migration a second time → no errors (idempotency check)