### PR TITLE
feat(hunt): dispatch local-agent tasks via browser SSE bridge

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -7,7 +7,7 @@ import redis.asyncio as aioredis
 
 from api.config import get_settings
 from api.db.session import create_all_tables
-from api.routers import auth, orchestrators, agents, chat, meetings, trust, conversations, hunt, bridge, projects, push
+from api.routers import auth, orchestrators, agents, chat, meetings, trust, conversations, hunt, bridge, projects, push, hunt_local
 
 settings = get_settings()
 
@@ -52,6 +52,7 @@ app.include_router(meetings.router)
 app.include_router(trust.router)
 app.include_router(conversations.router)
 app.include_router(hunt.router)
+app.include_router(hunt_local.router)
 app.include_router(bridge.router)
 app.include_router(projects.router)
 app.include_router(push.router)

--- a/api/models/agent.py
+++ b/api/models/agent.py
@@ -25,6 +25,9 @@ class AgentProtocol(str, Enum):
     a2a = "a2a"          # Google A2A — JSON-RPC tasks/send + Agent Card discovery
     acp = "acp"          # IBM/BeeAI ACP — REST POST /runs endpoint
     adapter = "adapter"  # No endpoint — uses akela-adapter SSE bridge
+    local = "local"      # Endpoint URL lives ONLY in the user's browser localStorage.
+                         # Hunt tasks dispatch via SSE to <LocalTaskWorker> in the
+                         # dashboard, which calls the user's local adapter directly.
 
 
 class Agent(Base):

--- a/api/routers/hunt_local.py
+++ b/api/routers/hunt_local.py
@@ -1,0 +1,313 @@
+"""
+Browser-resident local-agent bridge.
+
+Hunt task dispatch for agents with ``protocol == "local"`` cannot go through
+endpoint_caller.py (that code is server-side; the user's local agent URL is
+in browser localStorage, unreachable from the API server). Instead we route
+those dispatches to any open dashboard tab:
+
+    task_queue.py publishes JSON to redis channel  local-agent:{id}:notify
+             │
+             ▼
+    GET  /api/hunt/local/subscribe   (SSE)     ← dashboard <LocalTaskWorker>
+             │
+             ▼
+    Worker receives {task_id, agent_name, ...}, looks up localStorage
+    localAgents[agent_name] = {url, bearerToken}, calls
+    ${url}/  message/stream  with the task prompt.
+             │
+             ▼
+    POST /api/hunt/local/tasks/{id}/events   ← streamed artifact deltas
+    POST /api/hunt/local/tasks/{id}/done     ← terminal state (completed/failed)
+
+Both write-backs publish to the Den chat channel via pubsub so the response
+appears in Den as a message from the agent, and update the HuntTask row so
+the Hunt board reflects the terminal status.
+
+Auth: user Bearer JWT (same as other dashboard routes). The SSE endpoint
+reads the Authorization header via Depends(get_current_orchestrator_jwt).
+EventSource can't set headers, so the dashboard worker uses fetch-based
+SSE (response.body.getReader()) — which supports arbitrary headers.
+
+Known limitation (tracked in akela-ai#12): no claim lock between multiple
+browser tabs. Both tabs will execute the same task. That's acceptable for v1.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import uuid as uuid_lib
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.db.session import get_db
+from api.dependencies import get_current_orchestrator_jwt, get_redis
+from api.models.agent import Agent, AgentProtocol
+from api.models.hunt import HuntTask
+from api.models.message import Message, MentionType
+from api.models.orchestrator import Orchestrator
+from api.services import pubsub
+
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/api/hunt/local", tags=["hunt-local"])
+
+
+# ---------------------------------------------------------------------------
+# GET /api/hunt/local/subscribe  (SSE)
+# ---------------------------------------------------------------------------
+
+@router.get("/subscribe")
+async def subscribe(
+    request: Request,
+    current: Orchestrator = Depends(get_current_orchestrator_jwt),
+    redis_client = Depends(get_redis),
+):
+    """Subscribe to task_assigned events for the current user's local agents.
+
+    Emits one SSE event per Hunt dispatch:
+
+        event: task_assigned
+        data: {"task_id": "...", "agent_id": "...", "agent_name": "...",
+               "task_title": "...", "task_description": "...",
+               "dispatch_content": "@alpha 🎯 New Task: ...",
+               "room": "proj-<pid>"}
+
+    A ": ping\\n\\n" comment is emitted every 25s so proxies don't kill idle
+    connections.
+    """
+    orchestrator_id = str(current.id)
+
+    async def event_stream():
+        pubsub_conn = redis_client.pubsub()
+        await pubsub_conn.psubscribe("local-agent:*:notify")
+        logger.info("[hunt-local] %s subscribed to local-agent:*:notify", orchestrator_id)
+
+        # Initial event so the client knows it's connected.
+        yield "event: connected\ndata: {}\n\n"
+
+        last_ping = asyncio.get_event_loop().time()
+        try:
+            while True:
+                if await request.is_disconnected():
+                    break
+
+                msg = await pubsub_conn.get_message(
+                    ignore_subscribe_messages=True, timeout=5.0
+                )
+                now = asyncio.get_event_loop().time()
+
+                if msg is not None and msg.get("type") == "pmessage":
+                    raw = msg.get("data")
+                    if isinstance(raw, bytes):
+                        raw = raw.decode()
+                    try:
+                        event = json.loads(raw)
+                    except Exception:
+                        continue
+                    # Only forward events for agents owned by this orchestrator.
+                    if event.get("orchestrator_id") != orchestrator_id:
+                        continue
+                    payload = {
+                        "task_id": event.get("task_id"),
+                        "agent_id": event.get("agent_id"),
+                        "agent_name": event.get("agent_name"),
+                        "task_title": event.get("task_title", ""),
+                        "task_description": event.get("task_description", ""),
+                        "dispatch_content": event.get("content", ""),
+                        "room": event.get("room"),
+                    }
+                    yield f"event: task_assigned\ndata: {json.dumps(payload)}\n\n"
+
+                # 25s keepalive so reverse proxies don't cull the stream.
+                if now - last_ping > 25:
+                    yield ": ping\n\n"
+                    last_ping = now
+        finally:
+            try:
+                await pubsub_conn.punsubscribe("local-agent:*:notify")
+                await pubsub_conn.close()
+            except Exception:
+                pass
+            logger.info("[hunt-local] %s disconnected", orchestrator_id)
+
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+            "Connection": "keep-alive",
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# helpers: load + authz a Hunt task belonging to the current orchestrator
+# ---------------------------------------------------------------------------
+
+async def _load_owned_task(
+    task_id: str,
+    orchestrator_id: uuid_lib.UUID,
+    db: AsyncSession,
+) -> tuple[HuntTask, Agent]:
+    """Fetch task + agent, or 404 if not found / not owned."""
+    try:
+        task_uuid = uuid_lib.UUID(task_id)
+    except ValueError:
+        raise HTTPException(400, "Invalid task_id")
+
+    task_r = await db.execute(select(HuntTask).where(HuntTask.id == task_uuid))
+    task = task_r.scalar_one_or_none()
+    if not task or not task.assignee_id:
+        raise HTTPException(404, "Task not found")
+
+    agent_r = await db.execute(select(Agent).where(Agent.id == task.assignee_id))
+    agent = agent_r.scalar_one_or_none()
+    if not agent or agent.orchestrator_id != orchestrator_id:
+        raise HTTPException(404, "Task not found")
+
+    return task, agent
+
+
+# ---------------------------------------------------------------------------
+# POST /api/hunt/local/tasks/{id}/events
+# ---------------------------------------------------------------------------
+
+class EventPayload(BaseModel):
+    """A single delta posted by the browser worker while the task runs."""
+
+    artifact_text: str | None = Field(
+        default=None,
+        description="Accumulated assistant text so far. Each POST replaces the previous delta.",
+    )
+    tool_call: str | None = Field(
+        default=None,
+        description="Name of a tool the agent just invoked (shown as a status marker in Den).",
+    )
+    seq: int = Field(default=0, description="Monotonic sequence within this task.")
+
+
+@router.post("/tasks/{task_id}/events")
+async def post_event(
+    task_id: str,
+    payload: EventPayload,
+    current: Orchestrator = Depends(get_current_orchestrator_jwt),
+    db: AsyncSession = Depends(get_db),
+    redis_client = Depends(get_redis),
+):
+    """Forward a streamed artifact delta to Den so users see live progress."""
+    task, agent = await _load_owned_task(task_id, current.id, db)
+
+    if not (payload.artifact_text or payload.tool_call):
+        return {"status": "noop"}
+
+    # We intentionally DON'T persist every delta as a DB Message — too chatty.
+    # The final text lands in Den via /done. Here we publish a lightweight
+    # ephemeral event so any open Den tab can show "alpha is typing…"-style
+    # progress if it wants to.
+    room = f"proj-{task.epic.project_id}" if task.epic else ""
+    if room:
+        chunk_event = {
+            "type": "agent_chunk",
+            "agent_id": str(agent.id),
+            "agent_name": agent.name,
+            "task_id": str(task.id),
+            "text": payload.artifact_text or "",
+            "tool_call": payload.tool_call or "",
+            "seq": payload.seq,
+            "room": room,
+        }
+        await pubsub.publish(
+            pubsub.chat_channel(str(current.id), room), chunk_event, redis_client
+        )
+
+    return {"status": "ok"}
+
+
+# ---------------------------------------------------------------------------
+# POST /api/hunt/local/tasks/{id}/done
+# ---------------------------------------------------------------------------
+
+class DonePayload(BaseModel):
+    """Terminal status for a local-agent task.
+
+    ``state`` follows A2A v0.4.x: ``completed`` maps to Hunt status ``done``,
+    anything else (``failed``, ``cancelled``) maps to ``blocked``.
+    """
+
+    state: str = Field(..., description="A2A-style terminal state")
+    final_text: str = Field(default="", description="Full assistant response")
+    error: str = Field(default="", description="Failure reason if state != completed")
+
+
+@router.post("/tasks/{task_id}/done")
+async def post_done(
+    task_id: str,
+    payload: DonePayload,
+    current: Orchestrator = Depends(get_current_orchestrator_jwt),
+    db: AsyncSession = Depends(get_db),
+    redis_client = Depends(get_redis),
+):
+    """Mark a local-agent Hunt task as terminal and post its response to Den."""
+    task, agent = await _load_owned_task(task_id, current.id, db)
+    room = f"proj-{task.epic.project_id}" if task.epic else ""
+
+    # 1. Persist the final assistant response as a Message from the agent
+    #    so the Den conversation shows the answer.
+    if payload.final_text and room:
+        resp_msg = Message(
+            orchestrator_id=current.id,
+            agent_id=agent.id,
+            sender_name=agent.name,
+            sender_role="agent",
+            room=room,
+            content=payload.final_text,
+            mentions=[],
+            mention_type=MentionType.none,
+        )
+        db.add(resp_msg)
+        await db.commit()
+        await db.refresh(resp_msg)
+
+        await pubsub.publish(
+            pubsub.chat_channel(str(current.id), room),
+            {
+                "type": "message",
+                "id": str(resp_msg.id),
+                "agent_id": str(agent.id),
+                "sender_name": agent.name,
+                "sender_role": "agent",
+                "content": payload.final_text,
+                "mention_type": "none",
+                "mentions": [],
+                "room": room,
+                "created_at": resp_msg.created_at.strftime("%Y-%m-%dT%H:%M:%S") + "Z",
+            },
+            redis_client,
+        )
+
+    # 2. Update the HuntTask + post the "✅ Task completed" system message
+    #    — exactly what endpoint_caller does for remote agents. Keeps the
+    #    board in sync and advances the queue to the next task for this agent.
+    from api.services.endpoint_caller import _update_hunt_task
+
+    new_status = "done" if payload.state == "completed" else "blocked"
+    await _update_hunt_task(
+        task_id=str(task.id),
+        new_status=new_status,
+        agent=agent,
+        room=room,
+        orchestrator_id=str(current.id),
+        db=db,
+        redis_client=redis_client,
+    )
+
+    return {"status": "ok", "task_status": new_status}

--- a/api/routers/hunt_local.py
+++ b/api/routers/hunt_local.py
@@ -49,8 +49,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.db.session import get_db
 from api.dependencies import get_current_orchestrator_jwt, get_redis
-from api.models.agent import Agent, AgentProtocol
-from api.models.hunt import HuntTask
+from api.models.agent import Agent, AgentProtocol  # noqa: F401 — AgentProtocol used in docstring
+from api.models.hunt import Epic, HuntTask, Project as HuntProject
 from api.models.message import Message, MentionType
 from api.models.orchestrator import Orchestrator
 from api.services import pubsub
@@ -157,8 +157,15 @@ async def _load_owned_task(
     task_id: str,
     orchestrator_id: uuid_lib.UUID,
     db: AsyncSession,
-) -> tuple[HuntTask, Agent]:
-    """Fetch task + agent, or 404 if not found / not owned."""
+) -> tuple[HuntTask, Agent, str]:
+    """Fetch task + agent + the Den room, or 404 if not found / not owned.
+
+    We resolve the room via an explicit query on Epic + HuntProject rather
+    than the ``task.epic`` relationship: under SQLAlchemy async, lazy-loaded
+    relationships accessed outside the original load raise MissingGreenlet.
+    The explicit query is how the rest of the codebase already does it
+    (see task_queue._publish_task_status).
+    """
     try:
         task_uuid = uuid_lib.UUID(task_id)
     except ValueError:
@@ -174,7 +181,21 @@ async def _load_owned_task(
     if not agent or agent.orchestrator_id != orchestrator_id:
         raise HTTPException(404, "Task not found")
 
-    return task, agent
+    # Resolve the Den room for this task (proj-<hp.project_id>) without
+    # touching task.epic / epic.project (async-lazy hazard).
+    room = ""
+    if task.epic_id:
+        epic_r = await db.execute(select(Epic).where(Epic.id == task.epic_id))
+        epic = epic_r.scalar_one_or_none()
+        if epic:
+            hp_r = await db.execute(
+                select(HuntProject).where(HuntProject.id == epic.project_id)
+            )
+            hp = hp_r.scalar_one_or_none()
+            if hp and hp.project_id:
+                room = f"proj-{hp.project_id}"
+
+    return task, agent, room
 
 
 # ---------------------------------------------------------------------------
@@ -204,7 +225,7 @@ async def post_event(
     redis_client = Depends(get_redis),
 ):
     """Forward a streamed artifact delta to Den so users see live progress."""
-    task, agent = await _load_owned_task(task_id, current.id, db)
+    task, agent, room = await _load_owned_task(task_id, current.id, db)
 
     if not (payload.artifact_text or payload.tool_call):
         return {"status": "noop"}
@@ -213,7 +234,6 @@ async def post_event(
     # The final text lands in Den via /done. Here we publish a lightweight
     # ephemeral event so any open Den tab can show "alpha is typing…"-style
     # progress if it wants to.
-    room = f"proj-{task.epic.project_id}" if task.epic else ""
     if room:
         chunk_event = {
             "type": "agent_chunk",
@@ -257,8 +277,7 @@ async def post_done(
     redis_client = Depends(get_redis),
 ):
     """Mark a local-agent Hunt task as terminal and post its response to Den."""
-    task, agent = await _load_owned_task(task_id, current.id, db)
-    room = f"proj-{task.epic.project_id}" if task.epic else ""
+    task, agent, room = await _load_owned_task(task_id, current.id, db)
 
     # 1. Persist the final assistant response as a Message from the agent
     #    so the Den conversation shows the answer.

--- a/api/services/hunt_commands.py
+++ b/api/services/hunt_commands.py
@@ -379,9 +379,11 @@ async def _create_task(
             available = ", ".join(f"*{a.name}*" for a in all_agents[:5])
             return f"❌ Agent not found: **{agent_name}**. Available: {available or 'none'}", None
 
-        # Only A2A agents can receive task dispatch
-        if agent.protocol != AgentProtocol.a2a:
-            return f"❌ **{agent_name}** uses the `{agent.protocol.value}` protocol. Only A2A agents support task dispatch. Configure their endpoint as A2A in Pack settings.", None
+        # Only A2A / local agents can receive task dispatch.
+        # Local agents are dispatched to the user's browser via SSE and
+        # executed against the endpoint URL stored in browser localStorage.
+        if agent.protocol not in (AgentProtocol.a2a, AgentProtocol.local):
+            return f"❌ **{agent_name}** uses the `{agent.protocol.value}` protocol. Only A2A and local agents support task dispatch. Configure their endpoint as A2A (or Local) in Pack settings.", None
 
         # Validate agent is assigned to this project (if we're in a project room)
         if room_project_id:

--- a/api/services/task_queue.py
+++ b/api/services/task_queue.py
@@ -18,9 +18,22 @@ from sqlalchemy import select
 import redis.asyncio as aioredis
 
 from api.models.hunt import HuntTask, Epic, Story, Project as HuntProject
-from api.models.agent import Agent
+from api.models.agent import Agent, AgentProtocol
 from api.models.message import Message, MentionType
 from api.services import pubsub
+
+
+def _notify_channel(agent: Agent) -> str:
+    """Return the Redis channel a given agent listens on for dispatch.
+
+    Remote A2A agents are served by endpoint_caller.py's subscriber on
+    ``agent:{id}:notify``. Local agents are served by the browser-side
+    ``<LocalTaskWorker>`` subscribing to ``local-agent:{id}:notify`` via
+    the SSE bridge at ``/api/hunt/local/subscribe``.
+    """
+    if agent.protocol == AgentProtocol.local:
+        return f"local-agent:{agent.id}:notify"
+    return f"agent:{agent.id}:notify"
 
 
 async def _publish_task_status(task: HuntTask, status: str, orchestrator_id: str, db: AsyncSession, redis_client: aioredis.Redis):
@@ -135,9 +148,21 @@ async def dispatch_task(
     }
     await pubsub.publish(pubsub.chat_channel(orchestrator_id, room), dispatch_event, redis_client)
 
-    # Notify the agent via Redis (real-time) — include task_id so handler can update HuntTask
-    notify_event = {**dispatch_event, "task_id": str(task.id)}
-    await redis_client.publish(f"agent:{agent.id}:notify", json.dumps(notify_event))
+    # Notify the agent via Redis (real-time) — include task_id so handler can update HuntTask.
+    # Local agents are subscribed to via the browser-side SSE bridge; remote
+    # agents are subscribed to by endpoint_caller on the "agent:..." channel.
+    # orchestrator_id is included in the payload so the SSE bridge can filter
+    # by the current dashboard user without a DB query per event.
+    notify_event = {
+        **dispatch_event,
+        "task_id": str(task.id),
+        "agent_id": str(agent.id),
+        "agent_name": agent.name,
+        "orchestrator_id": str(orchestrator_id),
+        "task_title": task.title,
+        "task_description": task.description or "",
+    }
+    await redis_client.publish(_notify_channel(agent), json.dumps(notify_event))
 
 
 async def dispatch_or_queue(

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -10,6 +10,7 @@ import { Pack } from './pages/Pack'
 import { Settings } from './pages/Settings'
 import { Hunt } from './pages/Hunt'
 import { Login } from './pages/Login'
+import { LocalTaskWorker } from './workers/LocalTaskWorker'
 import api from './api'
 
 function ProtectedLayout() {
@@ -55,6 +56,10 @@ function ProtectedLayout() {
 
   return (
     <div style={{ display: 'flex', height: '100vh', overflow: 'hidden' }}>
+      {/* Renderless — dispatches Hunt tasks assigned to local agents by
+          calling the user's local endpoint (localStorage) directly. Mounts
+          once per authenticated session and survives route changes. */}
+      <LocalTaskWorker />
       <Sidebar />
       <main style={{ flex: 1, overflowY: 'auto', background: 'var(--bg-base)' }}>
         <Routes>

--- a/dashboard/src/pages/Pack.tsx
+++ b/dashboard/src/pages/Pack.tsx
@@ -244,12 +244,14 @@ function AgentCard({ agent, onDelete, onUpdate, readOnly = false }: {
               <select value={editProtocol} onChange={e => setEditProtocol(e.target.value)} style={{ ...inputStyle, width: 130 }}>
                 <option value="a2a">A2A (default)</option>
                 <option value="openai">OpenAI-compatible</option>
+                <option value="local">Local (browser)</option>
               </select>
             </div>
           </div>
           <div style={{ fontSize: 11, color: 'var(--text-muted)', marginBottom: 8, paddingLeft: 2 }}>
             {editProtocol === 'a2a' && '↳ Google A2A — supports Den chat + Hunt task dispatch. Exposes /.well-known/agent.json and tasks/sendSubscribe.'}
             {editProtocol === 'openai' && '↳ OpenAI-compatible — Den chat only. Task dispatch requires A2A. Exposes /v1/chat/completions.'}
+            {editProtocol === 'local' && '↳ Local (browser-resident) — URL lives in your browser localStorage. Den chat + Hunt tasks both run while any Akela tab is open.'}
           </div>
           <div style={{ marginBottom: 8 }}>
             <div style={{ fontSize: 10, color: 'var(--text-muted)', marginBottom: 4 }}>BEARER TOKEN <span style={{ fontWeight: 400 }}>(optional — sent as Authorization header)</span></div>
@@ -538,6 +540,7 @@ const handleDiscoverNew = async () => {
               >
                 <option value="a2a">A2A (default)</option>
                 <option value="openai">OpenAI-compatible</option>
+                <option value="local">Local (browser)</option>
               </select>
             </div>
             <div style={{ flex: 1 }}>
@@ -568,6 +571,7 @@ const handleDiscoverNew = async () => {
           <div style={{ fontSize: 11, color: 'var(--text-muted)', marginBottom: 12, paddingLeft: 2 }}>
             {protocol === 'a2a' && '↳ Google A2A — supports Den chat + Hunt task dispatch. Exposes /.well-known/agent.json and tasks/sendSubscribe.'}
             {protocol === 'openai' && '↳ OpenAI-compatible — Den chat only. Task dispatch requires A2A. Exposes /v1/chat/completions.'}
+            {protocol === 'local' && '↳ Local (browser-resident) — URL lives in your browser localStorage. Den chat + Hunt tasks both run while any Akela tab is open.'}
           </div>
 
           {/* Bearer token */}

--- a/dashboard/src/workers/LocalTaskWorker.tsx
+++ b/dashboard/src/workers/LocalTaskWorker.tsx
@@ -1,0 +1,335 @@
+/**
+ * <LocalTaskWorker /> — browser-resident Hunt task dispatcher for local agents.
+ *
+ * Hunt tasks assigned to agents with protocol='local' can't be dispatched
+ * server-side because their endpoint URL lives only in this browser's
+ * localStorage. Instead, the API server publishes Redis events that a
+ * dashboard-side SSE endpoint forwards to us; we then call the user's
+ * local agent directly and post the streamed response back to Akela.
+ *
+ *   server publishes → /api/hunt/local/subscribe (SSE)
+ *                    → this worker receives task_assigned
+ *                    → fetches localStorage[agentName] → {url, bearer}
+ *                    → POST  url/   with A2A message/stream
+ *                    → relays deltas to /api/hunt/local/tasks/{id}/events
+ *                    → on terminal state: /api/hunt/local/tasks/{id}/done
+ *
+ * The worker renders nothing. Mount it once somewhere that lives for the
+ * whole authenticated session (e.g. inside <ProtectedLayout />).
+ *
+ * Known v1 limitations (tracked upstream):
+ *   - No multi-tab claim lock — two open Akela tabs will both run the task
+ *     (akela-ai#12).
+ *   - No cancel / retry / resume hooks (akela-ai#13).
+ */
+
+import { useEffect, useRef } from 'react'
+import { useStore } from '../store'
+import { getLocalConfig } from '../local-chat'
+
+const API_BASE =
+  import.meta.env.VITE_API_URL ||
+  (import.meta.env.DEV ? 'http://localhost:8200' : '')
+
+type TaskAssignedEvent = {
+  task_id: string
+  agent_id: string
+  agent_name: string
+  task_title: string
+  task_description: string
+  dispatch_content: string
+  room: string
+}
+
+/** Artifact delta / tool_call event. Sent at most once every 400ms. */
+async function postProgressEvent(
+  taskId: string,
+  token: string,
+  body: { artifact_text?: string; tool_call?: string; seq: number },
+): Promise<void> {
+  try {
+    await fetch(`${API_BASE}/api/hunt/local/tasks/${taskId}/events`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify(body),
+    })
+  } catch (err) {
+    // Progress events are best-effort — failures don't abort the task.
+    console.warn('[LocalTaskWorker] /events failed:', err)
+  }
+}
+
+async function postDone(
+  taskId: string,
+  token: string,
+  body: { state: string; final_text: string; error?: string },
+): Promise<void> {
+  try {
+    await fetch(`${API_BASE}/api/hunt/local/tasks/${taskId}/done`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify(body),
+    })
+  } catch (err) {
+    console.error('[LocalTaskWorker] /done failed:', err)
+  }
+}
+
+/**
+ * Call the user's local agent with A2A message/stream and relay its
+ * SSE output back to Akela via /events + /done.
+ */
+async function executeTask(evt: TaskAssignedEvent, token: string): Promise<void> {
+  const config = getLocalConfig(evt.agent_name)
+  if (!config?.localEndpointUrl) {
+    await postDone(evt.task_id, token, {
+      state: 'failed',
+      final_text: '',
+      error: `No local endpoint URL configured for '${evt.agent_name}' in this browser.`,
+    })
+    return
+  }
+
+  const baseUrl = config.localEndpointUrl.replace(/\/+$/, '')
+  const prompt = evt.task_description
+    ? `${evt.task_title}\n\n${evt.task_description}`
+    : evt.task_title
+
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  if (config.localBearerToken) {
+    headers.Authorization = `Bearer ${config.localBearerToken}`
+  }
+
+  const payload = {
+    jsonrpc: '2.0',
+    id: crypto.randomUUID(),
+    method: 'message/stream',
+    params: {
+      message: {
+        messageId: crypto.randomUUID(),
+        role: 'user',
+        parts: [{ type: 'text', text: prompt }],
+      },
+      contextId: evt.task_id,
+      taskId: evt.task_id,
+    },
+  }
+
+  let resp: Response
+  try {
+    resp = await fetch(baseUrl + '/', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(payload),
+    })
+  } catch (err: any) {
+    await postDone(evt.task_id, token, {
+      state: 'failed',
+      final_text: '',
+      error: `Cannot reach local agent at ${baseUrl}: ${err?.message || err}`,
+    })
+    return
+  }
+
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => '')
+    await postDone(evt.task_id, token, {
+      state: 'failed',
+      final_text: '',
+      error: `Local agent HTTP ${resp.status}: ${text.slice(0, 300)}`,
+    })
+    return
+  }
+
+  const contentType = resp.headers.get('content-type') || ''
+  const reader = resp.body?.getReader()
+  if (!reader) {
+    await postDone(evt.task_id, token, {
+      state: 'failed',
+      final_text: '',
+      error: 'Local agent returned no response body.',
+    })
+    return
+  }
+
+  const decoder = new TextDecoder()
+  let buffer = ''
+  let accumulated = ''
+  let terminalState: string | null = null
+  let lastProgressAt = 0
+  let seq = 0
+
+  // Non-streaming fallback: local agent replied with a plain JSON-RPC
+  // response (because it doesn't implement message/stream). Parse the
+  // final artifact, post it, done.
+  if (!contentType.includes('text/event-stream')) {
+    const bodyText = await new Response(resp.body as any).text()
+    try {
+      const data = JSON.parse(bodyText)
+      const artifacts = data?.result?.artifacts || []
+      for (const a of artifacts) {
+        for (const p of a.parts || []) {
+          if ((p.kind === 'text' || p.type === 'text') && p.text) {
+            accumulated += p.text
+          }
+        }
+      }
+      await postDone(evt.task_id, token, {
+        state: 'completed',
+        final_text: accumulated || bodyText.slice(0, 500),
+      })
+    } catch (err: any) {
+      await postDone(evt.task_id, token, {
+        state: 'failed',
+        final_text: '',
+        error: `Could not parse local agent response: ${err?.message}`,
+      })
+    }
+    return
+  }
+
+  // Streaming path: parse A2A v0.4.x JSON-RPC envelopes from SSE.
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    buffer += decoder.decode(value, { stream: true })
+
+    let idx: number
+    while ((idx = buffer.indexOf('\n\n')) >= 0) {
+      const frame = buffer.slice(0, idx)
+      buffer = buffer.slice(idx + 2)
+
+      for (const line of frame.split('\n')) {
+        if (!line.startsWith('data:')) continue
+        const dataStr = line.slice(5).trim()
+        if (!dataStr) continue
+        let env: any
+        try {
+          env = JSON.parse(dataStr)
+        } catch {
+          continue
+        }
+        const result = env?.result
+        if (!result) continue
+
+        if (result.artifact) {
+          for (const part of result.artifact.parts || []) {
+            if (part.kind === 'text' || part.type === 'text') {
+              accumulated = part.text || accumulated
+            } else if (part.kind === 'data' && part.data?.type === 'tool_call') {
+              const now = performance.now()
+              if (now - lastProgressAt > 400) {
+                lastProgressAt = now
+                void postProgressEvent(evt.task_id, token, {
+                  tool_call: part.data.name,
+                  seq: seq++,
+                })
+              }
+            }
+          }
+          const now = performance.now()
+          if (accumulated && now - lastProgressAt > 400) {
+            lastProgressAt = now
+            void postProgressEvent(evt.task_id, token, {
+              artifact_text: accumulated,
+              seq: seq++,
+            })
+          }
+        }
+
+        if (result.status?.state) {
+          const state = result.status.state
+          if (state === 'completed' || state === 'failed' || state === 'cancelled') {
+            terminalState = state
+          }
+        }
+      }
+    }
+  }
+
+  await postDone(evt.task_id, token, {
+    state: terminalState || 'completed',
+    final_text: accumulated,
+    error: terminalState === 'failed' ? 'Agent reported failure.' : '',
+  })
+}
+
+
+export function LocalTaskWorker() {
+  const token = useStore(s => s.token)
+  const activeRef = useRef<Set<string>>(new Set())
+
+  useEffect(() => {
+    if (!token) return
+
+    const abort = new AbortController()
+    let reconnectTimer: number | undefined
+
+    const connect = async () => {
+      try {
+        const resp = await fetch(`${API_BASE}/api/hunt/local/subscribe`, {
+          headers: { Authorization: `Bearer ${token}` },
+          signal: abort.signal,
+        })
+        if (!resp.ok || !resp.body) {
+          throw new Error(`subscribe HTTP ${resp.status}`)
+        }
+
+        const reader = resp.body.getReader()
+        const decoder = new TextDecoder()
+        let buffer = ''
+
+        while (true) {
+          const { done, value } = await reader.read()
+          if (done) break
+          buffer += decoder.decode(value, { stream: true })
+
+          let idx: number
+          while ((idx = buffer.indexOf('\n\n')) >= 0) {
+            const frame = buffer.slice(0, idx)
+            buffer = buffer.slice(idx + 2)
+            if (frame.startsWith(':')) continue // keepalive
+
+            let eventName = 'message'
+            let dataLine = ''
+            for (const line of frame.split('\n')) {
+              if (line.startsWith('event:')) eventName = line.slice(6).trim()
+              else if (line.startsWith('data:')) dataLine += line.slice(5).trim()
+            }
+            if (eventName !== 'task_assigned' || !dataLine) continue
+
+            let evt: TaskAssignedEvent
+            try {
+              evt = JSON.parse(dataLine)
+            } catch {
+              continue
+            }
+
+            // De-dupe if the same tab receives the event twice within
+            // one SSE session (e.g. Redis re-delivery).
+            if (activeRef.current.has(evt.task_id)) continue
+            activeRef.current.add(evt.task_id)
+            console.info('[LocalTaskWorker] picked up', evt.task_id, 'for', evt.agent_name)
+
+            void executeTask(evt, token).finally(() => {
+              activeRef.current.delete(evt.task_id)
+            })
+          }
+        }
+      } catch (err: any) {
+        if (abort.signal.aborted) return
+        console.warn('[LocalTaskWorker] stream error, reconnecting in 5s:', err?.message)
+        reconnectTimer = window.setTimeout(connect, 5000)
+      }
+    }
+
+    void connect()
+
+    return () => {
+      abort.abort()
+      if (reconnectTimer !== undefined) window.clearTimeout(reconnectTimer)
+    }
+  }, [token])
+
+  return null
+}

--- a/migrations/011_agent_protocol_local.sql
+++ b/migrations/011_agent_protocol_local.sql
@@ -1,0 +1,36 @@
+-- 011_agent_protocol_local.sql
+-- Adds the new `local` value to AgentProtocol so Hunt tasks can be dispatched
+-- to browser-resident local agents (URL lives in localStorage, never in the DB).
+--
+-- SAEnum(AgentProtocol, native_enum=False) in SQLAlchemy creates a VARCHAR
+-- column with an implicit CHECK constraint. Postgres names the constraint
+-- <table>_<column>_check by convention. We drop + re-create it so the new
+-- value is accepted without rewriting any existing rows.
+
+BEGIN;
+
+-- Drop any existing check constraint on agents.protocol. The IF EXISTS
+-- guard makes this idempotent across fresh + existing deployments.
+DO $$
+DECLARE
+    constraint_name TEXT;
+BEGIN
+    SELECT con.conname
+      INTO constraint_name
+      FROM pg_constraint con
+      JOIN pg_class tbl ON con.conrelid = tbl.oid
+     WHERE tbl.relname = 'agents'
+       AND con.contype = 'c'
+       AND pg_get_constraintdef(con.oid) ILIKE '%protocol%';
+
+    IF constraint_name IS NOT NULL THEN
+        EXECUTE format('ALTER TABLE agents DROP CONSTRAINT %I', constraint_name);
+    END IF;
+END $$;
+
+-- Recreate the check constraint with the full enum set including `local`.
+ALTER TABLE agents
+    ADD CONSTRAINT agents_protocol_check
+    CHECK (protocol IN ('openai', 'a2a', 'acp', 'adapter', 'local'));
+
+COMMIT;


### PR DESCRIPTION
Fixes the gap where Hunt tasks assigned to a **local agent** (endpoint URL stored in browser localStorage, invisible to the server) had no execution path — the UI accepted the assignment but nothing ran.

## Architecture

```
Den /create-task → task_queue.dispatch_task
                    ├── protocol=a2a      → redis `agent:<id>:notify`  (existing)
                    └── protocol=local    → redis `local-agent:<id>:notify`
                                            │
                                            ▼
dashboard <LocalTaskWorker>  ←─ SSE GET /api/hunt/local/subscribe
   │
   ├── fetch localStorage[agent_name] → {url, bearer}
   ├── POST url/ with A2A message/stream (falls back to non-streaming)
   ├── stream artifact deltas back → POST /api/hunt/local/tasks/:id/events
   └── on terminal state          → POST /api/hunt/local/tasks/:id/done
                                    (persists final message to Den,
                                     updates HuntTask, advances queue)
```

The browser does the server's job for agents the server can't reach.

## Backend changes

- `api/models/agent.py` — new `AgentProtocol.local`.
- `migrations/011_agent_protocol_local.sql` — drops + re-creates the CHECK constraint on `agents.protocol` so Postgres accepts the new value. Idempotent.
- `api/services/hunt_commands.py` — dispatch gate now allows both `a2a` and `local`.
- `api/services/task_queue.py` — `dispatch_task` forks the Redis channel by protocol; notify payload carries `orchestrator_id` so the SSE bridge can filter.
- `api/routers/hunt_local.py` — new router with three endpoints, authenticated with the user JWT (same as other dashboard routes):
  - `GET /api/hunt/local/subscribe` (SSE) — pushes `task_assigned` events
  - `POST /api/hunt/local/tasks/{id}/events` — relays streaming artifact deltas
  - `POST /api/hunt/local/tasks/{id}/done` — terminal. Reuses `_update_hunt_task()` so Hunt board + queue advancement are identical to the remote-agent path.
- `api/main.py` — register `hunt_local.router`.

## Frontend changes

- `dashboard/src/workers/LocalTaskWorker.tsx` — renderless component that keeps an authenticated fetch-based SSE open for the whole session (EventSource can't set Authorization headers; fetch streaming can). Dispatches tasks via A2A `message/stream` with a graceful fallback to `message/send`. Reconnects on stream error. De-dupes task IDs within one session.
- `dashboard/src/App.tsx` — mount `<LocalTaskWorker />` inside `<ProtectedLayout />` so it lives across route changes.
- `dashboard/src/pages/Pack.tsx` — new `Local (browser)` option in the protocol dropdown, both new-agent and edit forms, plus description line.

## Known limitations (tracked separately)

- **#12 — multi-tab race.** Two open Akela tabs will both execute the same task (both see the SSE event). v1 ships without a claim lock; acceptable because nothing breaks, just duplicate effort.
- **#13 — cancel / retry / resume.** Neither local nor remote Hunt tasks currently support cancel / retry / resume. Separate issue for both.

## Database migration

Run `migrations/011_agent_protocol_local.sql` on your Postgres. Safe to re-run (guarded by `IF EXISTS` on the constraint lookup). No row rewrite — just relaxes the check.

## Test plan (post-deploy)

1. Install hermes-adapter on your laptop:
   ```
   curl -fsSL https://raw.githubusercontent.com/balaji-embedcentrum/hermes-adapter/main/scripts/install.sh | bash
   source ~/.hermes-venv/bin/activate
   hermes-adapter agent add alpha --model anthropic/claude-sonnet-4.6 --prompt-key
   hermes-adapter up
   ```
2. In Akela → Pack, edit the agent and set:
   - **PROTOCOL:** `Local (browser)`
   - **LOCAL ENDPOINT URL:** `http://127.0.0.1:9001`
3. In Den, run `/create-task "Write a sentence about the moon" #<epic> #<agent-name>`.
4. Expected: dispatch message shown in Den; agent response streams back and appears as a message from the agent; Hunt board shows the task as `done`; queue advances to the next assigned task if any.

## What does NOT change

- Remote A2A agents: unchanged. Same Redis channel, same endpoint_caller flow.
- `agent.endpoint_url`: still optional. Can be empty for `protocol=local` agents.
- Existing Den chat with local agents (via `local-chat.ts`): untouched — that was already browser-direct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)