### PR TITLE
fix(LocalTaskWorker): don't disturb response stream before SSE/JSON decision

### DIFF
--- a/dashboard/src/workers/LocalTaskWorker.tsx
+++ b/dashboard/src/workers/LocalTaskWorker.tsx
@@ -142,30 +142,37 @@ async function executeTask(evt: TaskAssignedEvent, token: string): Promise<void>
   }
 
   const contentType = resp.headers.get('content-type') || ''
-  const reader = resp.body?.getReader()
-  if (!reader) {
-    await postDone(evt.task_id, token, {
-      state: 'failed',
-      final_text: '',
-      error: 'Local agent returned no response body.',
-    })
-    return
-  }
-
-  const decoder = new TextDecoder()
-  let buffer = ''
-  let accumulated = ''
-  let terminalState: string | null = null
-  let lastProgressAt = 0
-  let seq = 0
 
   // Non-streaming fallback: local agent replied with a plain JSON-RPC
-  // response (because it doesn't implement message/stream). Parse the
-  // final artifact, post it, done.
+  // response (because it doesn't implement message/stream, or fell back
+  // to message/send, or returned a JSON-RPC method-not-found error).
+  // Read the full body ONCE via resp.text() and parse. We must NOT call
+  // resp.body.getReader() first — that locks the stream and would make
+  // the subsequent read throw "body is disturbed or locked".
   if (!contentType.includes('text/event-stream')) {
-    const bodyText = await new Response(resp.body as any).text()
+    let bodyText = ''
+    try {
+      bodyText = await resp.text()
+    } catch (err: any) {
+      await postDone(evt.task_id, token, {
+        state: 'failed',
+        final_text: '',
+        error: `Could not read local agent response: ${err?.message || err}`,
+      })
+      return
+    }
     try {
       const data = JSON.parse(bodyText)
+      // JSON-RPC error — adapter rejected message/stream (e.g. -32601).
+      if (data?.error) {
+        await postDone(evt.task_id, token, {
+          state: 'failed',
+          final_text: '',
+          error: `Local agent JSON-RPC error ${data.error.code}: ${data.error.message}`,
+        })
+        return
+      }
+      let accumulated = ''
       const artifacts = data?.result?.artifacts || []
       for (const a of artifacts) {
         for (const p of a.parts || []) {
@@ -187,6 +194,24 @@ async function executeTask(evt: TaskAssignedEvent, token: string): Promise<void>
     }
     return
   }
+
+  // Streaming path — only now do we read the body as a stream.
+  const reader = resp.body?.getReader()
+  if (!reader) {
+    await postDone(evt.task_id, token, {
+      state: 'failed',
+      final_text: '',
+      error: 'Local agent returned no response body.',
+    })
+    return
+  }
+
+  const decoder = new TextDecoder()
+  let buffer = ''
+  let accumulated = ''
+  let terminalState: string | null = null
+  let lastProgressAt = 0
+  let seq = 0
 
   // Streaming path: parse A2A v0.4.x JSON-RPC envelopes from SSE.
   while (true) {


### PR DESCRIPTION
## Symptom

After merging #14 and dispatching a Hunt task to a local agent, the task stays at **Chasing** (in_progress) forever. DevTools Console shows:

```
[LocalTaskWorker] picked up <task_id> for Local
Uncaught (in promise) TypeError: Failed to construct 'Response':
Response body object should not be disturbed or locked.
```

## Root cause

In `executeTask()`, the old code called `resp.body.getReader()` unconditionally, then **later** — if the content-type wasn't `text/event-stream` — tried to read the body again via `new Response(resp.body).text()`. The body was already locked to the first reader, so the second read throws.

This triggers whenever the local agent responds with anything other than SSE (e.g. a JSON-RPC method-not-found error from an older hermes-adapter that predates `message/stream`, or a fallback `message/send` JSON response).

## Fix

Read the response **once**, choosing the path by content-type first:

- `application/json` (or any non-SSE) → `await resp.text()` then `JSON.parse`
- `text/event-stream` → `resp.body.getReader()` and stream

Never both.

Also: a JSON-RPC `error` payload from the local agent (e.g. `-32601` method-not-found) is now reported back via `postDone` with a useful message, instead of silently slipping through as `bodyText.slice(0, 500)`.

## Test plan

1. Deploy this branch.
2. Dispatch a Hunt task to a local agent. Task should no longer get stuck at "Chasing":
   - If the local adapter returns SSE → streaming path, normal completion.
   - If the local adapter errors → task flips to "Blocked" with a descriptive error in Den.
3. No DevTools `TypeError: Failed to construct 'Response'` logs on task dispatch.

## Rollout

Frontend-only change. Rebuild dashboard:

```
git pull origin main
sudo docker compose -f docker-compose.prod.yml up -d --build dashboard
```

No migration, no API restart needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)