### PR TITLE
fix(hunt-local): worker body-lock crash + MentionType enum typo

### DIFF
--- a/api/routers/hunt_local.py
+++ b/api/routers/hunt_local.py
@@ -290,7 +290,7 @@ async def post_done(
             room=room,
             content=payload.final_text,
             mentions=[],
-            mention_type=MentionType.none,
+            mention_type=MentionType.normal,
         )
         db.add(resp_msg)
         await db.commit()
@@ -305,7 +305,7 @@ async def post_done(
                 "sender_name": agent.name,
                 "sender_role": "agent",
                 "content": payload.final_text,
-                "mention_type": "none",
+                "mention_type": "normal",
                 "mentions": [],
                 "room": room,
                 "created_at": resp_msg.created_at.strftime("%Y-%m-%dT%H:%M:%S") + "Z",


### PR DESCRIPTION
Two follow-up bugs to #14 found during real-world testing. Both reproduce on every local-agent Hunt task dispatch; together they blocked every task from completing.

## 1. Frontend — `TypeError: Failed to construct 'Response'`

`dashboard/src/workers/LocalTaskWorker.tsx`

Crash message:
```
Uncaught (in promise) TypeError: Failed to construct 'Response':
Response body object should not be disturbed or locked.
```

`executeTask()` called `resp.body.getReader()` unconditionally, then later — if content-type wasn't `text/event-stream` — tried to read the body a second time via `new Response(resp.body).text()`. The body was already locked to the first reader, so the second read threw, crashing the worker before it could post `/done`. Tasks stayed stuck at **Chasing** forever.

**Fix:** check content-type first, then choose ONE path:
- SSE → `resp.body.getReader()` and stream
- JSON → `await resp.text()` and parse

Never both.

While there, also treat a JSON-RPC error payload (e.g. `-32601` method-not-found from older adapters) as a proper failure in `postDone()` instead of silently reporting `completed` with a chunk of the error body.

## 2. Backend — `AttributeError: 'MentionType' object has no attribute 'none'`

`api/routers/hunt_local.py`

The `/done` endpoint 500'd on every call with:
```
File "/app/api/routers/hunt_local.py", line 293, in post_done
    mention_type=MentionType.none,
AttributeError: type object 'MentionType' has no attribute 'none'
```

I invented `MentionType.none`. The real enum (`api/models/message.py`) has `broadcast / direct / system / normal` — `normal` is the one used for messages without a mention. Same typo appeared again a few lines below in the pubsub payload string.

**Fix:** replace both `MentionType.none` → `MentionType.normal` and the string `"none"` → `"normal"`.

## Impact on existing behavior

None. Both fixes are inside code paths exercised only by local-agent Hunt dispatch (introduced in #14). Remote A2A agents, OpenAI agents, Den chat, and everything else are untouched.

## Rollout

Rebuild both services:

```bash
cd ~/akela-ai
git pull origin main
sudo docker compose -f docker-compose.prod.yml up -d --build api dashboard
```

No migration, no env changes.

## Test plan

1. Clear any stuck tasks (status='in_progress' or 'todo' for the local agent).
2. In Den: `/create-task "test" #<epic> #Local`.
3. Expected:
   - Chrome Console: `[LocalTaskWorker] picked up <id> for Local`, **no red errors**.
   - Den: dispatch message → streamed response from the agent → `✅ Task completed`.
   - Hunt board: `Chasing` → `Done`.

## Linked

Follow-up to #14. Doesn't close any issues on its own; #12 (multi-tab race) and #13 (cancel/retry/resume) remain open as planned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)