### PR TITLE
fix(hunt-local): cast agent.id to str when inserting Message

### DIFF
--- a/api/routers/hunt_local.py
+++ b/api/routers/hunt_local.py
@@ -282,9 +282,12 @@ async def post_done(
     # 1. Persist the final assistant response as a Message from the agent
     #    so the Den conversation shows the answer.
     if payload.final_text and room:
+        # Note: Message.agent_id is a String column (not UUID) — schema quirk.
+        # asyncpg rejects passing a UUID object directly; explicit str() is
+        # required to match what other writers in the codebase do.
         resp_msg = Message(
             orchestrator_id=current.id,
-            agent_id=agent.id,
+            agent_id=str(agent.id),
             sender_name=agent.name,
             sender_role="agent",
             room=room,


### PR DESCRIPTION
Third bug surfaced while testing local-agent Hunt dispatch end-to-end. Kept as a standalone PR per your one-fix-per-PR policy.

## Symptom

After the body-lock + MentionType fixes land, `/done` still 500's:

```
asyncpg.exceptions.DataError: invalid input for query argument $3:
UUID('4e181367-06d4-477b-8aab-784560d4d4... (expected str, got UUID)
```

## Root cause

`api/models/message.py:23` declares `Message.agent_id` as a **String** column, not UUID:

```python
agent_id: Mapped[str] = mapped_column(String, nullable=True)
```

(Schema quirk — the field can hold either an agent UUID or the literal string `"orchestrator"`.)

My `hunt_local.post_done()` handler passes `agent_id=agent.id` where `agent.id` is a Python `uuid.UUID`. asyncpg refuses to coerce and raises `DataError`.

## Fix

One-line cast: `agent_id=str(agent.id)`. Matches the string-column contract and how other writers in the codebase treat this field (task_queue.py dispatches with `agent_id=None`, so no conflict there).

## Test plan

1. Deploy this branch (api-only rebuild, no migration, no frontend change).
2. Clear stuck local-agent tasks:
   ```sql
   UPDATE hunt_tasks SET status='blocked'
    WHERE assignee_id=<local-agent-uuid>
      AND status IN ('in_progress','todo');
   ```
3. In Den: `/create-task "test" #<epic> #Local`.
4. Expected:
   - No 500 on `/done`.
   - Den shows a message from the local agent with the response body.
   - Hunt board flips `Chasing → Done`.

## Sits on top of #16

Builds directly on `main`; expects the two earlier hunt-local fixes in PR #16 to land first (else the same request still fails earlier in the chain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)