### PR TITLE
feat(hunt-local): 'Local is typing…' while the task streams

### DIFF
--- a/api/routers/hunt_local.py
+++ b/api/routers/hunt_local.py
@@ -231,10 +231,17 @@ async def post_event(
         return {"status": "noop"}
 
     # We intentionally DON'T persist every delta as a DB Message — too chatty.
-    # The final text lands in Den via /done. Here we publish a lightweight
-    # ephemeral event so any open Den tab can show "alpha is typing…"-style
-    # progress if it wants to.
+    # The final text lands in Den via /done. Here we publish two
+    # lightweight ephemeral events:
+    #   1. agent_chunk — raw delta, available to any custom UI that wants
+    #      streaming text for local agents.
+    #   2. typing — the contract Den's existing chat SSE listener already
+    #      handles (Den.tsx:655). Showing "Local is typing…" with a 45s
+    #      auto-timeout. Because we re-emit this on every delta, the 45s
+    #      timer resets as long as the agent keeps streaming — bursty
+    #      silence inside one task won't drop the indicator.
     if room:
+        chat_channel = pubsub.chat_channel(str(current.id), room)
         chunk_event = {
             "type": "agent_chunk",
             "agent_id": str(agent.id),
@@ -245,9 +252,14 @@ async def post_event(
             "seq": payload.seq,
             "room": room,
         }
-        await pubsub.publish(
-            pubsub.chat_channel(str(current.id), room), chunk_event, redis_client
-        )
+        await pubsub.publish(chat_channel, chunk_event, redis_client)
+
+        typing_event = {
+            "type": "typing",
+            "agent_name": agent.name,
+            "room": room,
+        }
+        await pubsub.publish(chat_channel, typing_event, redis_client)
 
     return {"status": "ok"}
 


### PR DESCRIPTION
Fixes #2 of two polish items from live testing: when a Hunt task is dispatched to a local agent, Den showed no typing/thinking indicator — the UI just went quiet until the final response landed. Remote agents display this correctly.

## What Den already does

\`dashboard/src/pages/Den.tsx:655\` listens on the chat SSE for:

\`\`\`js
else if (data.type === 'typing') {
  setTypingAgents(prev => [...prev, data.agent_name])
  // auto-clear after 45s
}
\`\`\`

and at line 677 it also clears the indicator when a message with \`sender_role === 'agent'\` arrives.

## Fix

In \`/api/hunt/local/tasks/{task_id}/events\` — already called by \`<LocalTaskWorker>\` on every streaming artifact delta — publish a \`typing\` event alongside the existing \`agent_chunk\`:

\`\`\`python
await pubsub.publish(chat_channel, {
    "type": "typing",
    "agent_name": agent.name,
    "room": room,
})
\`\`\`

Because deltas arrive several times per second and each re-emits \`typing\`, the 45s auto-clear timer is continuously reset. When the task finishes and \`/done\` posts the final \`agent\` message, Den's existing effect clears \`typingAgents\` for that name.

## Why it works for local agents without a new frontend path

The chat channel is \`pubsub.chat_channel(orchestrator_id, room)\` — the same one the existing Den SSE subscriber consumes (\`GET /chat/subscribe/alpha?room=proj-...\`). Any open Den tab in that room sees the event regardless of who posted it. No new frontend wiring.

## Not covered (intentional)

- An initial \"typing\" pulse at task-pickup time (before the first chunk). The adapter's first SSE frame is \`status: working\`, then artifacts start flowing. My worker doesn't call \`/events\` on \`status: working\` today, so there's a ~400ms–1s silent gap between dispatch and the first \"typing\" event. Acceptable for v1; follow-up if it feels laggy in practice.
- Cancelled / failed states don't emit typing — they transition to blocked and Den's post-message clear handles them.

## Test plan

1. Merge + rebuild \`api\` (no frontend rebuild needed — handler is already subscribed in Den):
   \`\`\`
   git pull origin main
   sudo docker compose -f docker-compose.prod.yml up -d --build api
   \`\`\`
2. In Den, \`/create-task \"write a long sentence\" #<epic> #Local\`.
3. Expected: within ~1 second of the dispatch message, \"**Local** is typing…\" appears at the bottom of Den. It persists while the agent streams. When the final message lands, it disappears automatically.

Depends on #14, #16, #17 (already merged). Independent of #18 (presence). Safe to merge in any order relative to #18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)