### PR TITLE
fix(hunt-local): emit typing indicator at dispatch time, not first chunk

### DIFF
--- a/api/services/task_queue.py
+++ b/api/services/task_queue.py
@@ -148,6 +148,23 @@ async def dispatch_task(
     }
     await pubsub.publish(pubsub.chat_channel(orchestrator_id, room), dispatch_event, redis_client)
 
+    # For local agents: emit a 'typing' indicator immediately on dispatch.
+    # Without this, Den has a visible dead zone between the dispatch message
+    # and the first streaming artifact (which could be several seconds of
+    # LLM latency). The /events endpoint re-emits typing on every chunk to
+    # refresh Den.tsx:655's 45s auto-clear timer.
+    # Remote agents don't need this here — endpoint_caller emits chunks
+    # faster than the 45s timeout via its own streaming flow.
+    if agent.protocol == AgentProtocol.local:
+        typing_event = {
+            "type": "typing",
+            "agent_name": agent.name,
+            "room": room,
+        }
+        await pubsub.publish(
+            pubsub.chat_channel(orchestrator_id, room), typing_event, redis_client
+        )
+
     # Notify the agent via Redis (real-time) — include task_id so handler can update HuntTask.
     # Local agents are subscribed to via the browser-side SSE bridge; remote
     # agents are subscribed to by endpoint_caller on the "agent:..." channel.


### PR DESCRIPTION
Small polish on top of #19. Testing showed the typing indicator appeared only after the first streaming delta from the local agent — several seconds after the \`@Local 🎯 New Task\` dispatch message. Den had a visible dead zone where users wondered if anything was happening.

## Fix

In \`task_queue.dispatch_task\`, right after publishing the dispatch message, also publish a \`typing\` event on the same chat channel when the target agent's protocol is \`local\`:

\`\`\`python
if agent.protocol == AgentProtocol.local:
    await pubsub.publish(chat_channel, {
        "type": "typing",
        "agent_name": agent.name,
        "room": room,
    }, redis_client)
\`\`\`

Den's SSE listener (Den.tsx:655) picks it up in the same render tick as the dispatch message, so "Local is typing…" appears immediately.

## Why local-only

Remote agents don't need this here — \`endpoint_caller\` emits chunks faster than Den's 45s typing-auto-clear timer via its own streaming flow. Local agents only emit on /events which needs the server to publish first; a priming emit at dispatch fills the gap.

## Chained behaviour

- dispatch_task — emits \`typing\` (new)
- every /events delta — re-emits \`typing\` (resets 45s timer) (from #19)
- /done with final message — Den's Den.tsx:677 effect clears typing when agent-role message arrives

## Rollout

api-only rebuild:

\`\`\`
git pull origin main
sudo docker compose -f docker-compose.prod.yml up -d --build api
\`\`\`

## Test plan

1. In Den: \`/create-task "long task" #<epic> #Local\`.
2. Expected: dispatch message (\`@Local 🎯 New Task\`) appears. **Within the same frame**, "Local is typing…" shows at the bottom of Den.
3. Indicator persists while streaming. Clears when final message from Local arrives.

Independent of any other open PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)