### PR TITLE
feat(hunt-local): atomic claim lock to prevent multi-tab duplicates (closes #12)

### DIFF
--- a/api/models/hunt.py
+++ b/api/models/hunt.py
@@ -105,6 +105,10 @@ class HuntTask(Base):
     estimate: Mapped[str] = mapped_column(String, nullable=True)
     issue_number: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     created_by: Mapped[str] = mapped_column(String, default="alpha")
+    # Claim lock for local-agent tasks. NULL until a browser tab claims
+    # the task via /api/hunt/local/tasks/{id}/claim; cleared again on /done.
+    # Only relevant for protocol='local' assignees — remote agents ignore it.
+    local_claim_id: Mapped[str | None] = mapped_column(String, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
     updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 

--- a/api/routers/hunt_local.py
+++ b/api/routers/hunt_local.py
@@ -272,6 +272,63 @@ async def _load_owned_task(
 
 
 # ---------------------------------------------------------------------------
+# POST /api/hunt/local/tasks/{id}/claim
+# ---------------------------------------------------------------------------
+
+class ClaimPayload(BaseModel):
+    """Per-tab claim request. `claim_id` is any browser-generated identifier
+    (the worker uses crypto.randomUUID()). Whichever tab claims first wins;
+    the losers drop the task."""
+
+    claim_id: str = Field(..., min_length=1)
+
+
+@router.post("/tasks/{task_id}/claim")
+async def claim(
+    task_id: str,
+    payload: ClaimPayload,
+    current: Orchestrator = Depends(get_current_orchestrator_jwt),
+    db: AsyncSession = Depends(get_db),
+):
+    """Atomically claim a local-agent task for a single browser tab.
+
+    Returns:
+      * 200 {claimed: true}  — this tab now owns the task, safe to execute
+      * 200 {claimed: false, claim_id: "<other>"} — another tab already
+                                                     claimed it; caller
+                                                     should silently drop
+      * 404 — task not found / not owned / not assigned
+    """
+    task, _agent, _room = await _load_owned_task(task_id, current.id, db)
+
+    # Atomic check-and-set using a WHERE clause on the current value.
+    # asyncpg + SQLAlchemy compile this as a single UPDATE ... WHERE ...,
+    # so two concurrent tabs racing to claim will see one success and
+    # one zero-row update without any extra locking.
+    result = await db.execute(
+        update(HuntTask)
+        .where(
+            HuntTask.id == task.id,
+            HuntTask.local_claim_id.is_(None),
+        )
+        .values(local_claim_id=payload.claim_id)
+    )
+    await db.commit()
+
+    if result.rowcount == 1:
+        return {"claimed": True, "claim_id": payload.claim_id}
+
+    # Read back whoever won so the caller can log it if they want.
+    await db.refresh(task)
+    # Same tab reclaiming its own task (e.g. page reload mid-execution)
+    # should also be treated as claimed so execution can continue.
+    if task.local_claim_id == payload.claim_id:
+        return {"claimed": True, "claim_id": payload.claim_id}
+
+    return {"claimed": False, "claim_id": task.local_claim_id}
+
+
+# ---------------------------------------------------------------------------
 # POST /api/hunt/local/tasks/{id}/events
 # ---------------------------------------------------------------------------
 
@@ -401,7 +458,16 @@ async def post_done(
             redis_client,
         )
 
-    # 2. Update the HuntTask + post the "✅ Task completed" system message
+    # 2. Clear the claim lock so a future reassignment (retry flow, etc.)
+    #    can start a fresh claim cycle across tabs.
+    await db.execute(
+        update(HuntTask)
+        .where(HuntTask.id == task.id)
+        .values(local_claim_id=None)
+    )
+    await db.commit()
+
+    # 3. Update the HuntTask + post the "✅ Task completed" system message
     #    — exactly what endpoint_caller does for remote agents. Keeps the
     #    board in sync and advances the queue to the next task for this agent.
     from api.services.endpoint_caller import _update_hunt_task

--- a/dashboard/src/workers/LocalTaskWorker.tsx
+++ b/dashboard/src/workers/LocalTaskWorker.tsx
@@ -75,11 +75,50 @@ async function postDone(
   }
 }
 
+/** Per-tab identifier used to claim tasks. Same value for the whole tab lifetime so
+ *  the same tab reloading mid-execution can reclaim its own task without contention. */
+const TAB_CLAIM_ID =
+  (typeof crypto !== 'undefined' && 'randomUUID' in crypto
+    ? crypto.randomUUID()
+    : `tab-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+
+/**
+ * Try to atomically claim a task for this tab. Returns true on success.
+ * If another Akela tab claimed it first, returns false — caller should
+ * silently drop the event so we don't double-dispatch to the local agent.
+ */
+async function tryClaim(taskId: string, token: string): Promise<boolean> {
+  try {
+    const resp = await fetch(`${API_BASE}/api/hunt/local/tasks/${taskId}/claim`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ claim_id: TAB_CLAIM_ID }),
+    })
+    if (!resp.ok) {
+      // 404 (task disappeared) / 401 (stale token) / 500 — treat as "don't run here"
+      return false
+    }
+    const data = await resp.json()
+    return !!data?.claimed
+  } catch (err) {
+    console.warn('[LocalTaskWorker] /claim failed, skipping task:', err)
+    return false
+  }
+}
+
 /**
  * Call the user's local agent with A2A message/stream and relay its
  * SSE output back to Akela via /events + /done.
  */
 async function executeTask(evt: TaskAssignedEvent, token: string): Promise<void> {
+  // Claim lock: only one Akela tab runs the task even when the user has
+  // several open. Fixes #12 (duplicate responses from multi-tab race).
+  const claimed = await tryClaim(evt.task_id, token)
+  if (!claimed) {
+    console.info('[LocalTaskWorker] dropping', evt.task_id, '— claimed by another tab')
+    return
+  }
+
   const config = getLocalConfig(evt.agent_name)
   if (!config?.localEndpointUrl) {
     await postDone(evt.task_id, token, {

--- a/migrations/012_hunt_tasks_local_claim.sql
+++ b/migrations/012_hunt_tasks_local_claim.sql
@@ -1,0 +1,20 @@
+-- 012_hunt_tasks_local_claim.sql
+-- Adds a claim lock for local-agent Hunt tasks so only one browser tab
+-- executes a given task even when the user has several Akela tabs open.
+--
+-- Semantics:
+--   * NULL         — nobody has claimed the task yet. The first
+--                    POST /api/hunt/local/tasks/{id}/claim wins.
+--   * non-NULL     — some tab already claimed it. Subsequent claims
+--                    return 409.
+--   * Cleared on /done so a new assignment (or /retry later) can start
+--                    a fresh claim cycle.
+--
+-- Idempotent — safe to re-run.
+
+BEGIN;
+
+ALTER TABLE hunt_tasks
+    ADD COLUMN IF NOT EXISTS local_claim_id TEXT NULL;
+
+COMMIT;


### PR DESCRIPTION
Fixes the duplicate-response bug visible in live testing: a single Hunt task to a local agent produced two different agent messages in Den. Root cause is the known multi-tab race from #12 — if the user has several Akela tabs open (incognito + normal, two windows, etc.), each \`<LocalTaskWorker>\` receives the same \`task_assigned\` SSE event and each one calls the user's local agent. Two LLM completions → two different haikus → both written back.

Closes #12.

## Fix: database-level atomic claim

Any tab must call \`POST /api/hunt/local/tasks/{id}/claim\` before touching the local agent. Postgres's single-statement UPDATE gives us free atomicity.

\`\`\`
UPDATE hunt_tasks
   SET local_claim_id = :tab_uuid
 WHERE id = :task_id
   AND local_claim_id IS NULL
\`\`\`

- \`rowcount == 1\` → this tab wins. Safe to execute.
- \`rowcount == 0\` → someone claimed it already. Drop silently, zero outbound calls.
- Same tab reclaiming its own task (page reload mid-execution) is treated as claimed — no double-dispatch, but the tab keeps running.

Claim is cleared in \`/done\` so a future reassignment / retry can start fresh.

## Changes

- **migrations/012_hunt_tasks_local_claim.sql** — adds \`local_claim_id TEXT NULL\`. Idempotent.
- **api/models/hunt.py** — new \`HuntTask.local_claim_id\` column.
- **api/routers/hunt_local.py** — new \`POST /tasks/{id}/claim\` endpoint; \`/done\` clears the claim.
- **dashboard/src/workers/LocalTaskWorker.tsx** — one-time \`TAB_CLAIM_ID\` per tab, calls \`/claim\` before execute, drops on refusal.

## Known edge

If a tab crashes mid-task (browser crash, laptop sleep kills WebSocket, etc.), \`local_claim_id\` stays non-NULL and the task is stranded. For now the escape hatch is:

\`\`\`sql
UPDATE hunt_tasks SET local_claim_id=NULL WHERE id='<task-uuid>';
\`\`\`

A proper fix belongs with #13 (cancel / retry / resume) where the resume sweeper can also clear stale claims past a timeout.

## Rollout

Migration + api + dashboard rebuild:

\`\`\`
git pull origin main
sudo docker compose -f docker-compose.prod.yml exec -T postgres \\
    psql -U akela -d akela < migrations/012_hunt_tasks_local_claim.sql
sudo docker compose -f docker-compose.prod.yml up -d --build api dashboard
\`\`\`

## Test plan

1. Open Akela in two Chrome windows / tabs, both logged in, both on a project with a local agent.
2. From one tab, \`/create-task "test" #<epic> #Local\`.
3. Expected: exactly ONE response message from Local in Den (not two).
4. Console on the losing tab shows: \`[LocalTaskWorker] dropping <task_id> — claimed by another tab\`.
5. Close all but one tab, reassign the task — normal single-tab execution still works.

Single-tab behavior is unchanged — tabs always claim their own tasks successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)