### PR TITLE
fix(hunt-local): close claim-lock race that produced duplicate responses

### DIFF
--- a/api/routers/hunt_local.py
+++ b/api/routers/hunt_local.py
@@ -305,11 +305,19 @@ async def claim(
     # asyncpg + SQLAlchemy compile this as a single UPDATE ... WHERE ...,
     # so two concurrent tabs racing to claim will see one success and
     # one zero-row update without any extra locking.
+    #
+    # The status='in_progress' guard is defence-in-depth: a task that's
+    # already finished (done/blocked) must NEVER be claimed again, even
+    # if its local_claim_id happens to be NULL for any reason (historical
+    # rows pre-dating this column, a retry flow that clears it, etc.).
+    # Without this guard, a delayed second subscriber could reclaim a
+    # just-completed task and run the whole thing over.
     result = await db.execute(
         update(HuntTask)
         .where(
             HuntTask.id == task.id,
             HuntTask.local_claim_id.is_(None),
+            HuntTask.status == "in_progress",
         )
         .values(local_claim_id=payload.claim_id)
     )
@@ -458,18 +466,19 @@ async def post_done(
             redis_client,
         )
 
-    # 2. Clear the claim lock so a future reassignment (retry flow, etc.)
-    #    can start a fresh claim cycle across tabs.
-    await db.execute(
-        update(HuntTask)
-        .where(HuntTask.id == task.id)
-        .values(local_claim_id=None)
-    )
-    await db.commit()
-
-    # 3. Update the HuntTask + post the "✅ Task completed" system message
+    # 2. Update the HuntTask + post the "✅ Task completed" system message
     #    — exactly what endpoint_caller does for remote agents. Keeps the
     #    board in sync and advances the queue to the next task for this agent.
+    #
+    # Note: we intentionally do NOT clear local_claim_id here. Earlier
+    # versions did, under the reasoning that a future retry flow would
+    # want to re-claim. But clearing it opened a race window between
+    # "claim cleared" and "status flipped to done" where a delayed
+    # second subscriber could win a fresh claim and run the task again,
+    # producing a duplicate response. The claim now stays set until the
+    # task is explicitly retried/reassigned (to be implemented in #13),
+    # and the defence-in-depth status='in_progress' guard in /claim
+    # blocks reclaims of already-terminal tasks.
     from api.services.endpoint_caller import _update_hunt_task
 
     new_status = "done" if payload.state == "completed" else "blocked"


### PR DESCRIPTION
## Symptom

A single Hunt task dispatched to a local agent was producing **two separate Local responses** in Den, each with different content (the two responses came from two independent LLM completions — one traditional Chinese, one simplified, for the same \"chinese poem\" task).

Verified from API logs — for ONE task the server received:

\`\`\`
POST claim          200
POST events × 3     200
POST done           200   ← first executeTask completes
POST events × 1     200   ← second executeTask mid-flight
POST done           200   ← second executeTask completes
\`\`\`

Two Message rows in the DB with same \`agent_id\`, same task, different content, 550 ms apart.

## Root cause

The old \`/done\` handler ran in this order:

\`\`\`python
1. INSERT Message                                     # the agent's response
2. UPDATE hunt_tasks SET local_claim_id = NULL        # clear the lock
3. _update_hunt_task()                                # sets status = 'done'
\`\`\`

Between step 2 and step 3 there's a window where `local_claim_id` is NULL but `status` is still `in_progress`. A delayed second subscriber (another device / tab / stale session — consistent with the user having multiple Akela sessions we couldn't fully rule out) arriving in that window hits:

\`\`\`sql
UPDATE hunt_tasks
   SET local_claim_id = :new_id
 WHERE id = :task_id
   AND local_claim_id IS NULL    ← succeeds because we just cleared it
\`\`\`

→ claim granted → executeTask runs the task a second time → second `/done` writes Message #2.

## Fix — two defences, both in this PR

**1. `/claim` gains a status guard.** Now requires:

\`\`\`sql
WHERE local_claim_id IS NULL
  AND status = 'in_progress'
\`\`\`

So an already-terminal task can never be reclaimed regardless of the state of `local_claim_id`.

**2. `/done` no longer clears `local_claim_id`.** Once claimed, a task stays claimed forever (as far as the local path is concerned). Retry / reassignment (#13) will clear the claim explicitly when it ships, using whatever new semantics that flow needs.

Belt + suspenders: even if future code accidentally clears the claim, the status guard in /claim still blocks reclaims.

## Rollout

api-only rebuild. No migration, no frontend change.

\`\`\`
cd ~/akela-ai
git pull origin main
sudo docker compose -f docker-compose.prod.yml up -d --build api
\`\`\`

## Test plan

1. Create a new task to your Local agent (`/create-task "test" #<epic> #Local`).
2. Wait for completion.
3. Check the DB — you should see exactly ONE row with `sender_name='Local'` for that task's room/time:
   \`\`\`sql
   SELECT id, sender_name, left(content, 60), created_at
   FROM messages
   WHERE sender_name='Local'
     AND created_at > NOW() - INTERVAL '5 minutes'
   ORDER BY created_at DESC;
   \`\`\`
4. Den should render exactly one Local response bubble + one `✅ Task completed` system message.

If a duplicate still shows up after this PR, the cause is elsewhere (not the claim race) and we'll dig in again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)