### PR TITLE
fix(hunt-local): make /done idempotent (survive proxy retries)

### DIFF
--- a/api/routers/hunt_local.py
+++ b/api/routers/hunt_local.py
@@ -429,6 +429,25 @@ async def post_done(
     """Mark a local-agent Hunt task as terminal and post its response to Den."""
     task, agent, room = await _load_owned_task(task_id, current.id, db)
 
+    # Idempotency guard. The same /done can arrive more than once:
+    #   * Traefik / reverse-proxy retry on a slow upstream response
+    #   * HTTP/2 or connection-pool re-send
+    #   * Browser network-stack retries on transient errors
+    # The worker reliably sends /done exactly once per executeTask run
+    # (verified via performance entries), but the server sometimes
+    # receives it twice — leading to a duplicate agent response message.
+    #
+    # If the task is no longer in_progress, a previous /done already
+    # wrote the Message, advanced the queue, and posted the system
+    # "Task completed" notification. Do nothing.
+    if task.status != "in_progress":
+        logger.info(
+            "[hunt-local] duplicate /done for %s (status=%s) — ignoring",
+            task.id,
+            task.status,
+        )
+        return {"status": "ok", "task_status": task.status, "duplicate": True}
+
     # 1. Persist the final assistant response as a Message from the agent
     #    so the Den conversation shows the answer.
     if payload.final_text and room:


### PR DESCRIPTION
Follow-up to #22. Even after closing the claim-lock race, local-agent tasks still produced duplicate Messages in Den. Correlated data nails down the cause:

| Source | Count |
|---|---|
| Console \`[LocalTaskWorker] picked up <id>\` | **1** per task |
| \`performance.getEntriesByType\` POSTs to \`http://127.0.0.1:9001/\` | **1** per task |
| API access log \`POST /.../done\` from same client connection | **2** per task |

So: browser sends \`/done\` exactly once, server receives it twice. The duplicate is being injected somewhere between browser and FastAPI — possible culprits:

- **Traefik retry** on slow upstream (`/done` does 2 DB commits + several Redis publishes, ~300ms)
- **HTTP/2 connection-pool re-send** on a hiccup
- **Browser network-stack retry** on transient socket-level error

All three are outside the worker's reach. The right fix is to make the endpoint **idempotent**.

## Fix

At the top of \`/done\`, check task status:

\`\`\`python
if task.status != "in_progress":
    logger.info("[hunt-local] duplicate /done for %s (status=%s) — ignoring",
                task.id, task.status)
    return {"status": "ok", "task_status": task.status, "duplicate": True}
\`\`\`

First POST → proceeds as before, flips task to \`done/blocked\`, writes Message, posts \"Task completed\".

Second POST → task is already terminal → no-op. Zero writes. Zero publishes. Returns 200 with \`duplicate: true\`.

No extra DB query — \`_load_owned_task\` already fetches the task.

## Rollout

api-only rebuild. No migration, no frontend.

\`\`\`
cd ~/akela-ai
git pull origin main
sudo docker compose -f docker-compose.prod.yml up -d --build api
\`\`\`

## Test plan

1. Dispatch a fresh local-agent task via /create-task.
2. Server log should show \`[hunt-local] duplicate /done for <task_id>\` once (confirming the second POST arrived but was ignored).
3. DB should have EXACTLY ONE row with \`sender_name='Local'\` for that task.
4. Den UI should show one agent response + one \"✅ Task completed\".

🤖 Generated with [Claude Code](https://claude.com/claude-code)