### PR TITLE
fix(hunt-local): make /events idempotent (phantom typing after task done)

### DIFF
--- a/api/routers/hunt_local.py
+++ b/api/routers/hunt_local.py
@@ -365,6 +365,14 @@ async def post_event(
     """Forward a streamed artifact delta to Den so users see live progress."""
     task, agent, room = await _load_owned_task(task_id, current.id, db)
 
+    # Idempotency guard — same pattern as /done. A proxy layer (Traefik /
+    # HTTP connection pool) sometimes retries our POSTs, so /events can
+    # arrive AFTER the task already completed. Publishing typing/chunk
+    # events at that point causes Den to show "Local is typing…"
+    # phantoms that disappear 45s later with no response.
+    if task.status != "in_progress":
+        return {"status": "ignored", "reason": "task terminal"}
+
     if not (payload.artifact_text or payload.tool_call):
         return {"status": "noop"}
 


### PR DESCRIPTION
Follow-up to #23. The idempotency guard there caught duplicate \`/done\` POSTs from the Traefik / proxy retry — but \`/events\` POSTs were still going through when retried, publishing \`typing\` + \`agent_chunk\` events to Den after the task was already terminal.

## Observed symptom (user report)

After a Hunt task completes:
1. Dispatch → \`Local is typing…\` appears ✓
2. Agent response renders in Den ✓
3. Task shows as Done ✓
4. A few seconds later — \`Local is typing…\` **appears again** ✗
5. 45 s pass with no real activity → auto-clear timer fires → indicator disappears
6. No new response ever arrives

## Root cause

\`/events\` had no status check. Traefik retries the same POST after the first \`/done\`. The delayed retry hits:

\`\`\`python
await pubsub.publish(chat_channel, {"type": "typing", ...})
\`\`\`

Den's listener registers it, shows the indicator, waits 45 s with no fresh typing events, times out. Classic phantom.

## Fix

Same one-line idempotency pattern as #23:

\`\`\`python
if task.status != "in_progress":
    return {"status": "ignored", "reason": "task terminal"}
\`\`\`

First \`/events\` call on an in-progress task: publishes chunk + typing as before.
Retried \`/events\` after task done: returns \`{ignored}\`, nothing published.

## Rollout

api-only rebuild. No migration, no frontend.

\`\`\`
cd ~/akela-ai
git pull origin main
sudo docker compose -f docker-compose.prod.yml up -d --build api
\`\`\`

## Test plan

1. Dispatch a fresh local-agent task.
2. Watch Den: typing appears, response arrives, typing clears.
3. Watch for ~60 s: phantom \"Local is typing…\" should NOT re-appear.
4. Server log should show the first \`POST /events\` as 200, any subsequent retries also 200 but with log body \`{"ignored"}\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)