### PR TITLE
feat(auth): add Google OAuth as a sign-in option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,14 @@ GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
 GITHUB_REDIRECT_URI=http://localhost:8200/akela-api/auth/github/callback
 
+# --- Google OAuth (optional) ---
+# Create OAuth 2.0 credentials at https://console.cloud.google.com/apis/credentials
+# (application type: Web application). The Authorized redirect URI must match
+# GOOGLE_REDIRECT_URI below exactly.
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GOOGLE_REDIRECT_URI=http://localhost:8200/akela-api/auth/google/callback
+
 # --- Production only ---
 # Your public domain (used by Traefik routing + GitHub OAuth callback).
 AKELA_DOMAIN=your-domain.example.com

--- a/api/config.py
+++ b/api/config.py
@@ -18,6 +18,11 @@ class Settings(BaseSettings):
     github_client_secret: str = ""
     github_redirect_uri: str = "http://localhost:8200/akela-api/auth/github/callback"
 
+    # Google OAuth
+    google_client_id: str = ""
+    google_client_secret: str = ""
+    google_redirect_uri: str = "http://localhost:8200/akela-api/auth/google/callback"
+
     api_host: str = "0.0.0.0"
     api_port: int = 8200
 

--- a/api/db/session.py
+++ b/api/db/session.py
@@ -36,6 +36,9 @@ async def run_migrations():
     migrations = [
         # Phase 7: multi-protocol agent support
         "ALTER TABLE agents ADD COLUMN IF NOT EXISTS protocol VARCHAR NOT NULL DEFAULT 'openai'",
+        # Google OAuth: per-orchestrator Google identity
+        "ALTER TABLE orchestrators ADD COLUMN IF NOT EXISTS google_id VARCHAR",
+        "CREATE UNIQUE INDEX IF NOT EXISTS orchestrators_google_id_key ON orchestrators (google_id)",
     ]
     async with engine.begin() as conn:
         for sql in migrations:

--- a/api/models/orchestrator.py
+++ b/api/models/orchestrator.py
@@ -11,6 +11,7 @@ class Orchestrator(Base):
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     github_id: Mapped[str] = mapped_column(String, unique=True, nullable=True)
+    google_id: Mapped[str] = mapped_column(String, unique=True, nullable=True)
     username: Mapped[str] = mapped_column(String, unique=True, nullable=True)
     name: Mapped[str] = mapped_column(String, nullable=False)
     email: Mapped[str] = mapped_column(String, nullable=True)

--- a/api/routers/auth.py
+++ b/api/routers/auth.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 from api.db.session import get_db
 from api.models.orchestrator import Orchestrator
 from api.services.auth_service import (
-    generate_api_key, get_github_user, create_jwt,
+    generate_api_key, get_github_user, get_google_user, create_jwt,
     verify_admin_credentials
 )
 from api.dependencies import get_current_orchestrator
@@ -101,6 +101,62 @@ async def github_callback(code: str, db: AsyncSession = Depends(get_db)):
             name=user.get("name") or user.get("login", "Unknown"),
             username=user.get("login", ""),
             email=user.get("email"),
+            admin_api_key=generate_api_key("alpha"),
+        )
+        db.add(orch)
+        await db.commit()
+        await db.refresh(orch)
+
+    token = create_jwt({"orchestrator_id": str(orch.id), "role": "alpha"})
+    params = urlencode({
+        "token": token,
+        "orchestrator_id": str(orch.id),
+        "name": orch.name or "",
+        "username": orch.username or "",
+        "admin_api_key": orch.admin_api_key,
+    })
+    return RedirectResponse(url=f"/pack/login?{params}")
+
+
+# Google OAuth
+@router.get("/google")
+async def google_login():
+    from urllib.parse import urlencode
+    params = urlencode({
+        "client_id": settings.google_client_id,
+        "redirect_uri": settings.google_redirect_uri,
+        "response_type": "code",
+        "scope": "openid email profile",
+        "access_type": "online",
+        "prompt": "select_account",
+    })
+    return RedirectResponse(f"https://accounts.google.com/o/oauth2/v2/auth?{params}")
+
+
+@router.get("/google/callback")
+async def google_callback(code: str, db: AsyncSession = Depends(get_db)):
+    from urllib.parse import urlencode
+    try:
+        user = await get_google_user(code)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    google_id = str(user.get("sub", ""))
+    if not google_id:
+        raise HTTPException(status_code=400, detail="Google account missing identifier")
+
+    result = await db.execute(select(Orchestrator).where(Orchestrator.google_id == google_id))
+    orch = result.scalar_one_or_none()
+
+    if not orch:
+        email = user.get("email") or ""
+        # Derive a username — Google has no handle, so use the email local-part.
+        username = email.split("@", 1)[0] if email else f"google_{google_id[:8]}"
+        orch = Orchestrator(
+            google_id=google_id,
+            name=user.get("name") or username,
+            username=username,
+            email=email or None,
             admin_api_key=generate_api_key("alpha"),
         )
         db.add(orch)

--- a/api/services/auth_service.py
+++ b/api/services/auth_service.py
@@ -54,3 +54,27 @@ async def get_github_user(code: str) -> dict:
             headers={"Authorization": f"Bearer {access_token}"},
         )
         return user_resp.json()
+
+
+async def get_google_user(code: str) -> dict:
+    async with httpx.AsyncClient() as client:
+        token_resp = await client.post(
+            "https://oauth2.googleapis.com/token",
+            data={
+                "client_id": settings.google_client_id,
+                "client_secret": settings.google_client_secret,
+                "code": code,
+                "grant_type": "authorization_code",
+                "redirect_uri": settings.google_redirect_uri,
+            },
+            headers={"Accept": "application/json"},
+        )
+        token_data = token_resp.json()
+        access_token = token_data.get("access_token")
+        if not access_token:
+            raise ValueError("Failed to get Google access token")
+        user_resp = await client.get(
+            "https://openidconnect.googleapis.com/v1/userinfo",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        return user_resp.json()

--- a/dashboard/src/components/Sidebar.tsx
+++ b/dashboard/src/components/Sidebar.tsx
@@ -5,7 +5,7 @@ import type { Project } from '../store'
 import { useDmNotifications } from '../hooks/useDmNotifications'
 import {
   LayoutDashboard, MessageSquare, Crosshair, Users,
-  Settings, LogOut, ExternalLink, ChevronLeft, ChevronRight,
+  Settings, LogOut, ChevronLeft, ChevronRight,
   ChevronDown, Plus, Menu, X,
 } from 'lucide-react'
 import api from '../api'
@@ -439,21 +439,6 @@ export function Sidebar() {
         </nav>
 
         {/* Bottom actions */}
-        <a
-          href="/"
-          title={collapsed ? 'Akela Host' : undefined}
-          style={{
-            display: 'flex', alignItems: 'center', gap: collapsed ? 0 : 8,
-            justifyContent: collapsed ? 'center' : 'flex-start',
-            padding: collapsed ? '11px 0' : '9px 16px',
-            textDecoration: 'none', color: 'var(--text-muted)',
-            fontSize: 13, borderTop: '1px solid var(--border)',
-          }}
-        >
-          <ExternalLink size={14} />
-          {!collapsed && 'Akela Host'}
-        </a>
-
         <button
           onClick={logout}
           title={collapsed ? 'Sign Out' : undefined}
@@ -463,6 +448,7 @@ export function Sidebar() {
             padding: collapsed ? '11px 0' : '9px 16px',
             border: 'none', background: 'transparent', color: 'var(--text-muted)',
             cursor: 'pointer', fontSize: 13, width: '100%',
+            borderTop: '1px solid var(--border)',
           }}
         >
           <LogOut size={14} />

--- a/dashboard/src/pages/Login.tsx
+++ b/dashboard/src/pages/Login.tsx
@@ -6,7 +6,7 @@ export function Login() {
   const { setUser, setToken } = useStore()
   const navigate = useNavigate()
 
-  // Handle GitHub OAuth callback redirect:
+  // Handle GitHub / Google OAuth callback redirect:
   // /pack/login?token=xxx&orchestrator_id=xxx&name=xxx&admin_api_key=xxx
   useEffect(() => {
     const params = new URLSearchParams(window.location.search)
@@ -68,8 +68,30 @@ export function Login() {
           Continue with GitHub
         </a>
 
+        <a
+          href="/akela-api/auth/google"
+          style={{
+            display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 10,
+            width: '100%', padding: '13px 24px', boxSizing: 'border-box',
+            marginTop: 12,
+            background: '#fff', border: '1px solid rgba(0,0,0,0.12)',
+            borderRadius: 8, color: '#1f1f1f', fontSize: 14, fontWeight: 600,
+            cursor: 'pointer', textDecoration: 'none', transition: 'background 0.2s',
+          }}
+          onMouseEnter={e => { (e.currentTarget as HTMLAnchorElement).style.background = '#f5f5f5' }}
+          onMouseLeave={e => { (e.currentTarget as HTMLAnchorElement).style.background = '#fff' }}
+        >
+          <svg height="20" width="20" viewBox="0 0 48 48">
+            <path fill="#FFC107" d="M43.611 20.083H42V20H24v8h11.303c-1.649 4.657-6.08 8-11.303 8-6.627 0-12-5.373-12-12s5.373-12 12-12c3.059 0 5.842 1.154 7.961 3.039l5.657-5.657C34.046 6.053 29.268 4 24 4 12.955 4 4 12.955 4 24s8.955 20 20 20 20-8.955 20-20c0-1.341-.138-2.65-.389-3.917z"/>
+            <path fill="#FF3D00" d="m6.306 14.691 6.571 4.819C14.655 15.108 18.961 12 24 12c3.059 0 5.842 1.154 7.961 3.039l5.657-5.657C34.046 6.053 29.268 4 24 4 16.318 4 9.656 8.337 6.306 14.691z"/>
+            <path fill="#4CAF50" d="M24 44c5.166 0 9.86-1.977 13.409-5.192l-6.19-5.238A11.91 11.91 0 0 1 24 36c-5.202 0-9.619-3.317-11.283-7.946l-6.522 5.025C9.505 39.556 16.227 44 24 44z"/>
+            <path fill="#1976D2" d="M43.611 20.083H42V20H24v8h11.303a12.04 12.04 0 0 1-4.087 5.571l.003-.002 6.19 5.238C36.971 39.205 44 34 44 24c0-1.341-.138-2.65-.389-3.917z"/>
+          </svg>
+          Continue with Google
+        </a>
+
         <p style={{ marginTop: 24, fontSize: 12, color: 'var(--text-muted)' }}>
-          Each GitHub account gets its own isolated pack.
+          Sign in with GitHub or Google — each account gets its own isolated pack.
         </p>
       </div>
     </div>

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -71,6 +71,9 @@ services:
       GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID}
       GITHUB_CLIENT_SECRET: ${GITHUB_CLIENT_SECRET}
       GITHUB_REDIRECT_URI: https://${AKELA_DOMAIN}/akela-api/auth/github/callback
+      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
+      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
+      GOOGLE_REDIRECT_URI: https://${AKELA_DOMAIN}/akela-api/auth/google/callback
     depends_on:
       postgres:
         condition: service_healthy

--- a/landing/index.html
+++ b/landing/index.html
@@ -266,7 +266,7 @@
       <div class="card">
         <div class="card-icon">🌐</div>
         <h3>Multi-User</h3>
-        <p>Each GitHub account gets its own isolated pack. Sign in with GitHub — no passwords, no setup.</p>
+        <p>Each account gets its own isolated pack. Sign in with GitHub or Google — no passwords, no setup.</p>
       </div>
     </div>
   </section>
@@ -279,7 +279,7 @@
         <div class="step-num">1</div>
         <div class="step-content">
           <h3>Sign in &amp; create your pack</h3>
-          <p>Log in with GitHub at <strong>akela-ai.com/pack</strong>. Your isolated pack is created automatically.</p>
+          <p>Log in with GitHub or Google at <strong>akela-ai.com/pack</strong>. Your isolated pack is created automatically.</p>
         </div>
       </div>
       <div class="step">


### PR DESCRIPTION
## Summary
- Adds Google OAuth alongside the existing GitHub OAuth flow — each Google account gets its own isolated Orchestrator (pack), keyed by a new `google_id` column.
- Wires the Google credentials through `docker-compose.prod.yml` so the API container actually sees them in production.
- Removes the leftover "Akela Host" link from the dashboard sidebar.

## Backend changes
- `api/config.py`: new `google_client_id` / `google_client_secret` / `google_redirect_uri` settings.
- `api/services/auth_service.py`: `get_google_user(code)` does the form-encoded token exchange against `oauth2.googleapis.com` and reads userinfo from the OIDC endpoint (`sub`, `email`, `name`).
- `api/models/orchestrator.py`: new `google_id` column, unique + nullable, same shape as `github_id`.
- `api/db/session.py`: idempotent migration adds the column and a unique index — safe to apply on existing prod DBs.
- `api/routers/auth.py`: `GET /auth/google` starts the flow with `openid email profile` scopes; `GET /auth/google/callback` finds-or-creates by `google_id` and redirects to `/pack/login` with the same query-string contract as GitHub, so the dashboard handles either provider unchanged. Username is derived from the email local-part (Google has no handle).

## Frontend changes
- `dashboard/src/pages/Login.tsx`: "Continue with Google" button below the GitHub button (white background per Google brand guidance, full-color G icon).
- `landing/index.html`: feature card and step 1 copy updated from "Sign in with GitHub" to "Sign in with GitHub or Google".

## Deploy / config changes
- `.env.example`: new `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` / `GOOGLE_REDIRECT_URI` block.
- `docker-compose.prod.yml`: passes the three Google vars into the `api` service. `GOOGLE_REDIRECT_URI` is derived from `AKELA_DOMAIN` so it stays in lockstep with the public hostname.

## Test plan
- [ ] Create OAuth 2.0 Web application credentials at https://console.cloud.google.com/apis/credentials
- [ ] Add `https://<AKELA_DOMAIN>/akela-api/auth/google/callback` as an authorized redirect URI
- [ ] Set `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` in the VPS `.env`
- [ ] `docker compose -f docker-compose.prod.yml up -d --build` → confirm the `google_id` column + unique index appear on `orchestrators`
- [ ] Visit `/pack/login` → both buttons render, "Continue with Google" redirects through Google and lands back on the dashboard authenticated
- [ ] Existing GitHub login still works
- [ ] Sidebar no longer shows the "Akela Host" link