### PR TITLE
feat(dashboard): clickable 'New Project' + open chat from pack roster

### DIFF
--- a/dashboard/src/components/Sidebar.tsx
+++ b/dashboard/src/components/Sidebar.tsx
@@ -177,11 +177,14 @@ function ProjectSwitcher({ collapsed }: { collapsed: boolean }) {
               onClick={() => setCreating(true)}
               style={{
                 display: 'flex', alignItems: 'center', gap: 7,
-                padding: '8px 12px', cursor: 'pointer', fontSize: 12,
-                color: 'var(--text-muted)', borderTop: '1px solid var(--border)',
+                padding: '8px 12px', cursor: 'pointer', fontSize: 12, fontWeight: 600,
+                color: 'var(--text-primary)', borderTop: '1px solid var(--border)',
+                transition: 'background 0.15s',
               }}
-              onMouseEnter={e => e.currentTarget.style.color = 'var(--text-primary)'}
-              onMouseLeave={e => e.currentTarget.style.color = 'var(--text-muted)'}
+              onMouseEnter={e => { e.currentTarget.style.background = 'var(--bg-hover)' }}
+              onMouseLeave={e => { e.currentTarget.style.background = 'transparent' }}
+              onMouseDown={e => { e.currentTarget.style.background = 'var(--bg-elevated)' }}
+              onMouseUp={e => { e.currentTarget.style.background = 'var(--bg-hover)' }}
             >
               <Plus size={12} /> New Project
             </div>

--- a/dashboard/src/pages/Dashboard.tsx
+++ b/dashboard/src/pages/Dashboard.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { useStore } from '../store'
 import type { Project, Agent } from '../store'
 import api from '../api'
@@ -138,6 +139,7 @@ function ProjectRow({
 
 export function Dashboard() {
   const { agents, setAgents, projects } = useStore()
+  const navigate = useNavigate()
   const [stats, setStats] = useState<Record<string, ProjectStat>>({})
   // projectAgentIds keyed by project.id
   const [projectAgents, setProjectAgents] = useState<Record<string, Set<string>>>({})
@@ -250,10 +252,18 @@ export function Dashboard() {
                 No agents yet. Go to The Pack to register one.
               </div>
             ) : agents.map((a, i) => (
-              <div key={a.id} style={{
-                display: 'flex', alignItems: 'center', gap: 10, padding: '10px 14px',
-                borderBottom: i < agents.length - 1 ? '1px solid var(--border)' : 'none',
-              }}>
+              <div
+                key={a.id}
+                onClick={() => navigate(`/chat/${a.name}`)}
+                title={`Open chat with ${a.display_name || a.name}`}
+                style={{
+                  display: 'flex', alignItems: 'center', gap: 10, padding: '10px 14px',
+                  borderBottom: i < agents.length - 1 ? '1px solid var(--border)' : 'none',
+                  cursor: 'pointer', transition: 'background 0.15s',
+                }}
+                onMouseEnter={e => { e.currentTarget.style.background = 'var(--bg-hover)' }}
+                onMouseLeave={e => { e.currentTarget.style.background = 'transparent' }}
+              >
                 <div style={{
                   width: 8, height: 8, borderRadius: '50%', flexShrink: 0,
                   background: a.status === 'online' ? 'var(--online)' : a.status === 'busy' ? 'var(--busy)' : 'var(--offline)',


### PR DESCRIPTION
## Summary
Two small UX fixes for the dashboard, bundled together because they're both one-screen tweaks reported in the same review pass.

## Sidebar — \`New Project\` row
- Was rendered in muted gray (\`var(--text-muted)\`) with only a tiny \`+\` icon and a hover that flipped just the text color. Read as disabled at a glance, so it was being skipped.
- Now: white text by default (\`var(--text-primary)\`, weight 600), full row picks up \`bg-hover\` on hover, deeper \`bg-elevated\` on mousedown so the click is visually acknowledged the instant before the create-project form opens.

## Dashboard — \`THE PACK\` roster on the right
- Each agent row was inert; clicking did nothing.
- Now navigates to \`/chat/<agent.name>\` — the same route the sidebar DM list already uses. Added \`cursor: pointer\`, hover background, and a \`title="Open chat with <Display Name>"\` tooltip so the affordance is obvious.
- This makes the Dashboard page a viable jump-off point for DMs without forcing users to drop into the sidebar first.

## Test plan
- [ ] Sidebar 'New Project' renders white by default, not gray.
- [ ] Hovering it shows a background fill across the whole row.
- [ ] Clicking it darkens momentarily then opens the inline 'New project' input as before.
- [ ] On the Dashboard, hovering an agent in the right-hand 'THE PACK' panel shows a hover background.
- [ ] Clicking an agent there opens \`/chat/<name>\` and the chat window loads for that agent.
- [ ] Existing sidebar DM clicks still work unchanged.