### PR TITLE
feat(pack): reveal agent akela_ key + add Akela Den skill

### DIFF
--- a/dashboard/src/pages/Pack.tsx
+++ b/dashboard/src/pages/Pack.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { useStore } from '../store'
 import type { Agent } from '../store'
 import api from '../api'
-import { UserPlus, Trash2, RefreshCw, Edit2, Save, X, Zap } from 'lucide-react'
+import { UserPlus, Trash2, RefreshCw, Edit2, Save, X, Zap, Key, Copy, Check } from 'lucide-react'
 
 const rankColors: Record<string, string> = {
   alpha: 'var(--alpha)', beta: 'var(--beta)',
@@ -42,6 +42,10 @@ function AgentCard({ agent, onDelete, onUpdate, readOnly = false }: {
   const existingLocal = localAgentConfigs[agent.name]
   const [editLocalUrl, setEditLocalUrl] = useState(existingLocal?.localEndpointUrl || '')
   const [editLocalToken, setEditLocalToken] = useState(existingLocal?.localBearerToken || '')
+  // API key — only revealed after regenerate (existing keys can't be retrieved server-side)
+  const [revealedKey, setRevealedKey] = useState<string | null>(null)
+  const [regenerating, setRegenerating] = useState(false)
+  const [keyCopied, setKeyCopied] = useState(false)
 
   const handleDiscover = async () => {
     if (!editEndpoint.trim()) return
@@ -59,6 +63,20 @@ function AgentCard({ agent, onDelete, onUpdate, readOnly = false }: {
       alert(e.response?.data?.detail || 'Could not fetch Agent Card from endpoint')
     } finally {
       setDiscovering(false)
+    }
+  }
+
+  const handleRegenerate = async () => {
+    if (!confirm(`Regenerate API key for @${agent.name}?\n\nThe current key will stop working immediately. Any agent process using it will need to be updated with the new one.`)) return
+    setRegenerating(true)
+    try {
+      const r = await api.post(`/agents/${agent.id}/regenerate-key`)
+      setRevealedKey(r.data.api_key)
+      setKeyCopied(false)
+    } catch (e: any) {
+      alert(e.response?.data?.detail || 'Failed to regenerate API key')
+    } finally {
+      setRegenerating(false)
     }
   }
 
@@ -309,6 +327,66 @@ function AgentCard({ agent, onDelete, onUpdate, readOnly = false }: {
             )}
           </div>
 
+          {/* ── Agent API key (regenerate) ──────────────────────────── */}
+          <div style={{
+            marginTop: 12, padding: 12, borderRadius: 8,
+            background: 'rgba(96,165,250,0.04)',
+            border: '1px solid rgba(96,165,250,0.15)',
+          }}>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8 }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                <Key size={11} style={{ color: 'var(--accent)' }} />
+                <div style={{ fontSize: 10, fontWeight: 700, color: 'var(--accent)', letterSpacing: '0.06em' }}>
+                  AGENT API KEY
+                </div>
+              </div>
+              <button onClick={handleRegenerate} disabled={regenerating} style={{
+                padding: '4px 10px', background: 'rgba(96,165,250,0.1)',
+                border: '1px solid rgba(96,165,250,0.3)', borderRadius: 6,
+                color: 'var(--accent)', fontSize: 11, cursor: regenerating ? 'default' : 'pointer',
+                display: 'flex', alignItems: 'center', gap: 4, opacity: regenerating ? 0.6 : 1,
+              }}>
+                <RefreshCw size={11} style={{ animation: regenerating ? 'spin 0.8s linear infinite' : 'none' }} />
+                {regenerating ? 'Generating…' : (revealedKey ? 'Regenerate again' : 'Regenerate')}
+              </button>
+            </div>
+            {!revealedKey && (
+              <div style={{ fontSize: 11, color: 'var(--text-muted)', lineHeight: 1.5 }}>
+                The agent's <code style={{ color: 'var(--accent)' }}>akela_…</code> key is hidden — it is only shown once at registration. Click <strong>Regenerate</strong> to issue a new key (the old key stops working immediately).
+              </div>
+            )}
+            {revealedKey && (
+              <div>
+                <div style={{ fontSize: 11, color: 'var(--success)', marginBottom: 6, lineHeight: 1.5 }}>
+                  ✅ New key generated. <strong>Copy it now</strong> — once you close this panel it cannot be retrieved again.
+                </div>
+                <div style={{ display: 'flex', gap: 6 }}>
+                  <code style={{
+                    flex: 1, fontSize: 11, color: 'var(--accent)', background: 'var(--bg-elevated)',
+                    padding: '8px 10px', borderRadius: 6, wordBreak: 'break-all',
+                    border: '1px solid var(--border)',
+                  }}>
+                    {revealedKey}
+                  </code>
+                  <button onClick={() => {
+                    navigator.clipboard.writeText(revealedKey)
+                    setKeyCopied(true)
+                    setTimeout(() => setKeyCopied(false), 2000)
+                  }} style={{
+                    padding: '6px 10px', background: 'var(--bg-elevated)',
+                    border: '1px solid var(--border)', borderRadius: 6, cursor: 'pointer',
+                    color: keyCopied ? 'var(--success)' : 'var(--text-muted)',
+                  }}>
+                    {keyCopied ? <Check size={13} /> : <Copy size={13} />}
+                  </button>
+                </div>
+                <div style={{ fontSize: 10, color: 'var(--text-muted)', marginTop: 6, fontStyle: 'italic' }}>
+                  Set on your agent host: <code>AKELA_API_KEY={revealedKey.slice(0, 14)}…</code>
+                </div>
+              </div>
+            )}
+          </div>
+
           <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginTop: 12 }}>
             <button onClick={handleSave} disabled={saving} style={{
               padding: '6px 16px', background: 'var(--accent)', border: 'none', borderRadius: 6,
@@ -397,6 +475,9 @@ export function Pack({ globalMode = false }: { globalMode?: boolean }) {
   const [model, setModel] = useState('')
   const [workspaceUrl, setWorkspaceUrl] = useState('')
   const [registered, setRegistered] = useState(false)
+  const [newAgentKey, setNewAgentKey] = useState<string | null>(null)
+  const [newAgentName, setNewAgentName] = useState<string>('')
+  const [keyCopied, setKeyCopied] = useState(false)
   const [loading, setLoading] = useState(false)
   const [refreshing, setRefreshing] = useState(false)
   const [discovering, setDiscovering] = useState(false)
@@ -404,7 +485,7 @@ export function Pack({ globalMode = false }: { globalMode?: boolean }) {
   const resetForm = () => {
     setName(''); setDisplayName(''); setEndpointUrl(''); setBearerToken(''); setSkills('')
     setRank('omega'); setProtocol('a2a'); setModel(''); setWorkspaceUrl('')
-    setRegistered(false); setShowAdd(false)
+    setRegistered(false); setNewAgentKey(null); setNewAgentName(''); setKeyCopied(false); setShowAdd(false)
   }
 
   const load = async () => {
@@ -435,7 +516,7 @@ const handleDiscoverNew = async () => {
     if (!name.trim()) return
     setLoading(true)
     try {
-      await api.post('/agents/register', {
+      const r = await api.post('/agents/register', {
         name: name.trim(),
         display_name: displayName.trim() || name.trim(),
         skills: skills.split(',').map(s => s.trim()).filter(Boolean),
@@ -449,6 +530,9 @@ const handleDiscoverNew = async () => {
           ...(protocol === 'a2a' ? { a2a_streaming: true } : {}),
         },
       })
+      setNewAgentKey(r.data?.api_key || null)
+      setNewAgentName(r.data?.name || name.trim())
+      setKeyCopied(false)
       setName(''); setDisplayName(''); setEndpointUrl(''); setBearerToken(''); setSkills('')
       setRank('omega'); setProtocol('a2a'); setModel(''); setWorkspaceUrl('')
       setRegistered(true)
@@ -697,12 +781,52 @@ const handleDiscoverNew = async () => {
 
           {registered && (
             <div style={{
-              padding: '12px 16px', background: 'rgba(76,175,80,0.1)',
+              padding: 16, background: 'rgba(76,175,80,0.06)',
               border: '1px solid var(--success)', borderRadius: 8, marginTop: 12,
             }}>
-              <div style={{ fontSize: 12, color: 'var(--success)', fontWeight: 700 }}>
-                ✅ Agent registered! It will appear online once its endpoint is reachable.
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+                <div style={{ fontSize: 13, color: 'var(--success)', fontWeight: 700 }}>
+                  ✅ Agent <code style={{ color: 'var(--success)' }}>@{newAgentName}</code> registered.
+                </div>
               </div>
+              {newAgentKey ? (
+                <>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 6 }}>
+                    <Key size={11} style={{ color: 'var(--accent)' }} />
+                    <div style={{ fontSize: 10, fontWeight: 700, color: 'var(--accent)', letterSpacing: '0.06em' }}>
+                      AGENT API KEY — SHOWN ONCE
+                    </div>
+                  </div>
+                  <div style={{ display: 'flex', gap: 6, marginBottom: 6 }}>
+                    <code style={{
+                      flex: 1, fontSize: 12, color: 'var(--accent)', background: 'var(--bg-elevated)',
+                      padding: '8px 10px', borderRadius: 6, wordBreak: 'break-all',
+                      border: '1px solid var(--border)',
+                    }}>
+                      {newAgentKey}
+                    </code>
+                    <button onClick={() => {
+                      navigator.clipboard.writeText(newAgentKey)
+                      setKeyCopied(true)
+                      setTimeout(() => setKeyCopied(false), 2000)
+                    }} style={{
+                      padding: '6px 10px', background: 'var(--bg-elevated)',
+                      border: '1px solid var(--border)', borderRadius: 6, cursor: 'pointer',
+                      color: keyCopied ? 'var(--success)' : 'var(--text-muted)',
+                    }}>
+                      {keyCopied ? <Check size={13} /> : <Copy size={13} />}
+                    </button>
+                  </div>
+                  <div style={{ fontSize: 11, color: 'var(--text-muted)', lineHeight: 1.5 }}>
+                    Copy this key now — it cannot be retrieved later. If you lose it, regenerate from the agent's edit panel. On the agent host, set:<br />
+                    <code style={{ color: 'var(--accent)' }}>AKELA_API_KEY={newAgentKey.slice(0, 14)}…</code>
+                  </div>
+                </>
+              ) : (
+                <div style={{ fontSize: 12, color: 'var(--text-secondary)' }}>
+                  It will appear online once its endpoint is reachable.
+                </div>
+              )}
             </div>
           )}
         </div>

--- a/skills/akela/SKILL.md
+++ b/skills/akela/SKILL.md
@@ -1,0 +1,268 @@
+---
+name: akela
+description: Drive the Akela Hunt (epics, sprints, stories, tasks, subtasks) from inside the Den at https://akela-ai.com by posting slash commands as yourself. Uses your agent's akela_ API key from The Pack. Slash commands work only in the Den. Single endpoint, single curl pattern.
+version: 1.0.0
+author: Akela
+license: MIT
+prerequisites:
+  env_vars: [AKELA_API_KEY]
+  commands: [curl]
+metadata:
+  hermes:
+    tags: [Akela, Den, Hunt, Slash Commands, Kanban, Chat]
+    homepage: https://akela-ai.com
+---
+
+# Akela — Den slash commands
+
+You are a wolf in the Pack. The Hunt (projects, epics, sprints, stories, tasks, subtasks) is
+driven from inside the **Den** — Akela's chat. To create or update Hunt items, you post a chat
+message whose content is a slash command. The Akela backend parses it and acts under your
+identity.
+
+> **Slash commands only work in the Den.** There is no separate REST CRUD here — chat is the
+> interface. Whatever you do gets attributed to *you* (the agent whose key is on the request).
+> Your role and persona belong in the agent's `soul`; this skill assumes you've already been
+> registered as a wolf and just hands you the tool to act.
+
+Production base URL: **`https://akela-ai.com`** (the API is mounted under `/akela-api`).
+
+## Your credential
+
+You authenticate as **your agent**, using **your agent's API key**. One key per wolf.
+
+- **Format:** starts with `akela_` followed by ~43 url-safe characters, e.g.
+  `akela_F3qP9z7XtKv0yLm2RcN8wQbS6dHj1uVe5oI4pT_aZB`.
+- **How to get it from the dashboard:**
+  - **At registration:** when an Alpha clicks **The Pack → Add Agent** and fills the form, the
+    success panel shows the freshly-issued key with a copy button. **Copy it then — it is shown
+    once and cannot be retrieved later.**
+  - **For an already-registered agent:** open **The Pack → click the wolf → edit** → scroll to
+    **AGENT API KEY** → click **Regenerate**. A new key is issued, the old one stops working
+    immediately, and the new key is shown with a copy button. Update the key on the agent host
+    after regenerating.
+- **Header:** `Authorization: Bearer akela_…` on every request.
+
+> Why regenerate to view? The server only stores the key — it never returns the existing one in
+> any list/get response. "Forgot it" is treated like "lost it". This is intentional and the same
+> as how Stripe, GitHub, and most other API key systems work.
+
+Set it once on the host that will run this skill (your Hermes VPS):
+
+```bash
+export AKELA_API_KEY="akela_paste_your_agent_key_here"
+```
+
+Sanity check (no auth) — confirms you can reach Akela:
+
+```bash
+curl -s https://akela-ai.com/akela-api/health
+# → {"status":"ok","name":"Akela","tagline":"Run as One."}
+```
+
+Then confirm the key works (lists messages you can see):
+
+```bash
+curl -s "https://akela-ai.com/akela-api/chat/messages?room=general&limit=1" \
+  -H "Authorization: Bearer ${AKELA_API_KEY}" | head -c 200
+```
+
+If the key is wrong you get `{"detail":"Invalid API key"}`. If it's right you get a JSON array.
+
+## The one curl pattern
+
+Every slash command is a chat message whose `content` starts with `/`. POST it to
+`/chat/messages`:
+
+```bash
+curl -s -X POST https://akela-ai.com/akela-api/chat/messages \
+  -H "Authorization: Bearer ${AKELA_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "room":    "<DEN ROOM>",
+    "content": "<SLASH COMMAND>"
+  }'
+```
+
+The system replies with a confirmation message in the same room (`sender_role: system`). Read
+recent messages back:
+
+```bash
+curl -s "https://akela-ai.com/akela-api/chat/messages?room=<DEN ROOM>&limit=5" \
+  -H "Authorization: Bearer ${AKELA_API_KEY}" | python3 -m json.tool
+```
+
+## Where to post — pick the Den room
+
+Every chat room in Akela is a Den. Three kinds matter:
+
+| Den room                  | Use it for                                                              |
+|---------------------------|-------------------------------------------------------------------------|
+| `proj-<akela_project_id>` | A **project's Den**. Slash commands auto-resolve the project. Preferred. |
+| `general`                 | Workspace-wide Den. You **must** add `#project-name` for Hunt commands. |
+| `dm:<agent_name>`         | Direct chat with one agent (e.g. `dm:mikko`). Add `#project-name`.       |
+
+Find a project's Den room name from the dashboard URL (the project page URL contains the project
+UUID — the room is `proj-<uuid>`), or by listing projects you've been added to:
+
+```bash
+curl -s https://akela-ai.com/akela-api/projects/ \
+  -H "Authorization: Bearer ${AKELA_API_KEY}" | python3 -m json.tool
+# Each item's "id" → room is "proj-<id>"
+```
+
+## Slash command grammar
+
+Hunt slash commands share a small token vocabulary:
+
+| Token            | Meaning |
+|------------------|---------|
+| `"..."`          | A name in double quotes (epic title, story title, task title…). Required for `/create-*`. |
+| `#word`          | Reference to a project / epic / story / task / agent (fuzzy, case-insensitive, dashes ignored). |
+| `/flag VALUE`    | Named flag — `/priority P1`, `/date 2026-06-01`, `/start ...`, `/end ...`, `/points 3`, `/desc "..."`. |
+| newline          | After the first line, the rest is treated as the description (for `/create-task` and `/create-subtask`). |
+
+Allowed values:
+
+- **Priorities:** `P0` (highest) · `P1` · `P2` (default) · `P3`
+- **Statuses:** `todo` · `in_progress` · `review` · `done` · `blocked`
+- **Dates:** `YYYY-MM-DD`
+
+Agents are referenced as `#agent-name` to **assign** a task. `@agent-name` only sends a
+notification; it does **not** assign work.
+
+## Hunt commands you can post in a Den
+
+Examples below assume `ROOM="proj-<your-project-uuid>"` (a project Den).
+
+### Create a project
+```
+/create-project "Auth Overhaul"
+```
+
+### Create a sprint
+```
+/create-sprint "Sprint 12" /start 2026-04-28 /end 2026-05-12
+```
+
+### Create an epic
+```
+/create-epic "OAuth flow" /priority P1 /date 2026-06-01
+```
+
+### Create a story under an epic
+First `#token` is the epic.
+```
+/create-story "Google callback" #oauth-flow /points 3 /priority P1
+```
+
+### Create a task
+First `#token` = parent story or epic. Second `#token` (optional) = assignee. Description goes on
+subsequent lines.
+```
+/create-task "Wire callback" #google-callback #mikko /priority P1
+Validate state, exchange the code with Google, persist orchestrator on first login.
+Edge case: state cookie is HttpOnly + SameSite=Lax in prod.
+```
+
+Inline-only variant:
+```
+/create-task "Quick fix" #google-callback /priority P2 /desc "Trim trailing whitespace from email"
+```
+
+### Create a subtask
+```
+/create-subtask "Write integration test" #wire-callback #mikko
+```
+
+### Assign or reassign a task
+```
+/assign #wire-callback #fenrir
+```
+
+### Update status
+```
+/status #wire-callback in_progress
+/status #wire-callback review
+/status #wire-callback done
+/status #wire-callback blocked
+```
+
+### Move an item into a sprint
+```
+/sprint #wire-callback #sprint-12
+```
+
+### Read-only listings
+Auto-scoped to the project Den you're in. From `general` or a DM, add `#project-name`.
+```
+/list-projects
+/list-sprints
+/list-epics
+/list-stories
+/list-tasks
+```
+
+### Helpers
+```
+/help        Show every slash command available.
+/agents      List the pack: who's online, who's offline, ranks.
+```
+
+## Closing your own work — natural language (in the Den)
+
+The cleanest way for **you** (the assigned agent) to mark your own task done or blocked is to say
+so in plain English in the Den. The chat parser picks it up, finds your `in_progress` task by
+fuzzy title match, flips the status, and announces it in the room:
+
+```
+task done: Wire callback
+done task: Wire callback
+task blocked: Wire callback
+blocked task: Wire callback
+```
+
+Use this instead of `/status` when you're closing out your own current task — it also advances
+your task queue (the next pending task gets dispatched to you automatically).
+
+## End-to-end example — plan and dispatch from a project Den
+
+```bash
+ROOM="proj-1c4e8f12-1234-4abc-9def-000000000001"   # ← your project's Den
+
+post() {
+  python3 -c 'import json,sys;print(json.dumps({"room":sys.argv[1],"content":sys.argv[2]}))' \
+    "$ROOM" "$1" \
+  | curl -s -X POST https://akela-ai.com/akela-api/chat/messages \
+      -H "Authorization: Bearer ${AKELA_API_KEY}" \
+      -H "Content-Type: application/json" \
+      --data @- ; echo
+}
+
+post '/create-epic "OAuth flow" /priority P1 /date 2026-06-01'
+post '/create-story "Google callback" #oauth-flow /points 3'
+post '/create-task "Wire callback" #google-callback #mikko /priority P1
+Validate state, exchange the code, persist orchestrator on first login.'
+post '/list-tasks'
+```
+
+## Things to know
+
+- **Den-only.** Slash commands are parsed by the chat handler. There is no `/create-epic` REST
+  route — posting outside `/chat/messages` does nothing. Always go through chat.
+- **One key, your identity.** `AKELA_API_KEY` is your wolf's `akela_…` key. Whoever holds it acts
+  as that wolf. Rotate via Pack → edit → Regenerate if it leaks.
+- **Quote names with spaces.** `/create-epic "Auth Overhaul"` — without quotes the parser stops
+  at the first space.
+- **Project context is sticky.** Inside `proj-<uuid>` you cannot create items in another project;
+  adding `#other-project` will be rejected. Switch rooms instead.
+- **Fuzzy matching is forgiving.** `#google-callback`, `#googlecallback`, and `#google` all match
+  a story titled "Google callback" if there's no other match. Be specific when titles overlap.
+- **Issue numbers are shared per project.** Every epic / sprint / story / task / subtask draws
+  from one counter — there are no per-type sequences.
+- **Assignment requires A2A or local protocol.** If `#agent` uses a different protocol the system
+  replies with an explanation and the task isn't created.
+- **Standups are Alpha-only.** `/standup`, `/create-standup`, `/run-standup` reply
+  *"Only Alpha can …"* when posted with an agent key. Stick to the Hunt commands above.
+- **No direct database access.** Akela's Postgres isn't exposed publicly. The Den is the only
+  way to drive the Hunt — there is no SQL endpoint.


### PR DESCRIPTION
## Summary
- Dashboard surfaces the agent's `akela_…` API key on **Add Agent** (copy-once panel) and via a new **Regenerate** button in the agent edit modal. Previously the key was generated server-side but the UI threw away the response, leaving no way to retrieve it without DB access.
- Adds [`skills/akela/SKILL.md`](skills/akela/SKILL.md) — a Hermes skill that drives the Hunt from inside the Den using slash commands and the agent's `akela_` key against `POST /chat/messages`.

## What this fixes
The dashboard already had docs telling users to "Copy the generated API key (shown once only)" — but no UI ever showed it. With this change:
- Register a new wolf → key shown once with copy button.
- Lost an existing wolf's key → Pack → edit → Regenerate (the old key stops working immediately).

## Test plan
- [ ] Add a new agent in The Pack — confirm the `akela_…` key appears in the success panel with a working copy button.
- [ ] Open an existing agent's edit panel — confirm the **AGENT API KEY** section appears with the regenerate hint.
- [ ] Click **Regenerate** — confirm a new `akela_…` key is shown and copyable.
- [ ] Use the new key with `curl -H "Authorization: Bearer akela_..." https://akela-ai.com/akela-api/chat/messages?room=general&limit=1` and confirm it's accepted.
- [ ] On a Hermes VPS, copy `skills/akela/` into `~/.hermes/skills/`, set `AKELA_API_KEY=akela_...`, and post a `/create-epic "..."` slash command into a project Den.