### PR TITLE
feat(a2a): mode flag for individual-chat agent-owned memory

### DIFF
--- a/api/services/a2a_caller.py
+++ b/api/services/a2a_caller.py
@@ -101,12 +101,34 @@ async def call_a2a(
     orchestrator_id: str = "",
     hunt_task_id: str = "",
     attachments: list[dict] | None = None,
+    *,
+    context_id: str | None = None,
+    embed_history: bool = True,
 ) -> tuple[str, dict, str, str]:
     """
     Send a task to an A2A agent via message/stream (streaming) or message/send.
 
     Returns (full_text, meta, stream_id, final_state).
     final_state: "completed" | "failed" | "working" | "unknown"
+
+    Mode flags (keyword-only, both default to legacy text-stuffing
+    behavior so Den/Hunt callers see no change):
+
+    ``context_id``
+        When set, included as ``message.contextId`` in the outbound A2A
+        envelope. Spec-compliant A2A v1.0 agents key conversation memory
+        to this id. Used by individual-chat callers to let the agent
+        own its multi-turn memory; ``None`` for orchestrator flows
+        where the orchestrator owns the canonical history.
+
+    ``embed_history``
+        ``True`` (default) preserves the existing behavior of stuffing
+        prior turns into a ``[Prior conversation]`` block in the
+        message body — required for Den (per-agent bubble filtering)
+        and Hunt (orchestrator picks different agents per turn).
+        ``False`` skips the in-band stuff so the agent reads its own
+        prior turns from its session store. Pair with ``context_id``
+        for individual chat.
     """
     endpoint_url = agent.endpoint_url.rstrip("/")
     bearer_token = agent.bearer_token or ""
@@ -130,12 +152,14 @@ async def call_a2a(
             endpoint_url, content, room, agent.name,
             stream_id, redis_client, history, orchestrator_id, headers,
             attachments=attachments,
+            context_id=context_id, embed_history=embed_history,
         )
     else:
         full_text, usage, final_state = await _call_send(
             endpoint_url, content, room, agent.name,
             stream_id, redis_client, history, orchestrator_id, headers,
             attachments=attachments,
+            context_id=context_id, embed_history=embed_history,
         )
 
     meta = BaseAgentCaller.build_meta(usage, start_ts, soul)
@@ -158,9 +182,15 @@ async def _call_stream(
     orchestrator_id: str,
     headers: dict,
     attachments: list[dict] | None = None,
+    *,
+    context_id: str | None = None,
+    embed_history: bool = True,
 ) -> tuple[str, dict, str]:
     payload = _build_jsonrpc("message/stream", {
-        "message": _build_message(content, history, attachments),
+        "message": _build_message(
+            content, history, attachments,
+            context_id=context_id, embed_history=embed_history,
+        ),
     })
 
     accumulated = ""
@@ -234,6 +264,7 @@ async def _call_stream(
         text, usage, state = await _call_send(
             endpoint_url, content, room, agent_name,
             stream_id, redis_client, history, orchestrator_id, headers,
+            context_id=context_id, embed_history=embed_history,
         )
         return text, usage, state, []
 
@@ -253,9 +284,15 @@ async def _call_send(
     orchestrator_id: str,
     headers: dict,
     attachments: list[dict] | None = None,
+    *,
+    context_id: str | None = None,
+    embed_history: bool = True,
 ) -> tuple[str, dict, str]:
     payload = _build_jsonrpc("message/send", {
-        "message": _build_message(content, history, attachments),
+        "message": _build_message(
+            content, history, attachments,
+            context_id=context_id, embed_history=embed_history,
+        ),
     })
 
     try:
@@ -295,9 +332,34 @@ def _build_jsonrpc(method: str, params: dict) -> dict:
     }
 
 
-def _build_message(content: str, history: list[dict] | None, attachments: list[dict] | None = None) -> dict:
+def _build_message(
+    content: str,
+    history: list[dict] | None,
+    attachments: list[dict] | None = None,
+    *,
+    context_id: str | None = None,
+    embed_history: bool = True,
+) -> dict:
+    """Build an A2A v1.0 message object.
+
+    The ``embed_history`` flag controls whether prior turns are stuffed
+    into the message body as a ``[Prior conversation]`` block:
+
+    * ``True`` (default): Den/Hunt — Akela owns the canonical history,
+      filters per-agent (Den's bubble) or picks different agents per
+      turn (Hunt). Each call carries the relevant slice in-band.
+    * ``False``: individual chat — agent owns its memory via its session
+      store keyed on ``context_id``. ``history`` is still accepted but
+      not embedded; pass ``[]`` or ``None`` to skip the local query.
+
+    The ``context_id`` flag, when set, is included as
+    ``message.contextId`` per A2A v1.0. Spec-compliant agents key
+    persistent conversation memory to this id. Required for the agent
+    to load its own history when ``embed_history=False``; harmless
+    otherwise.
+    """
     parts = []
-    if history:
+    if embed_history and history:
         history_lines = []
         for turn in history:
             role = "User" if turn["role"] == "user" else "Assistant"
@@ -321,11 +383,14 @@ def _build_message(content: str, history: list[dict] | None, attachments: list[d
             except Exception:
                 text_content = b64
             parts.append({"kind": "text", "text": f"\n[Attachment: {name}]\n{text_content}"})
-    return {
+    msg: dict = {
         "messageId": str(uuid.uuid4()),
         "role": "user",
         "parts": parts,
     }
+    if context_id:
+        msg["contextId"] = context_id
+    return msg
 
 
 def _extract_text_from_task(task: dict) -> str:

--- a/api/services/endpoint_caller.py
+++ b/api/services/endpoint_caller.py
@@ -394,12 +394,30 @@ async def handle_agent_notify(
         json.dumps({"type": "typing", "agent_name": agent.name, "room": room}),
     )
 
+    # Identify individual-chat rooms (created by api/routers/conversations.py
+    # as ``chat-<uuid12>``). Den project rooms (``proj-*``) and the default
+    # group channel (``general``) keep the orchestrator-owned history model.
+    # Meeting rooms are detected by ``meeting_id`` and never get history.
+    # Hunt rooms always carry ``hunt_task_id`` and are also orchestrator-driven.
+    is_individual_chat = (
+        room.startswith("chat-")
+        and not meeting_id
+        and not hunt_task_id
+    )
+
     # Build history for any non-meeting room — DMs and project/group rooms
     # both benefit from context. Meetings are one-shot broadcast prompts and
     # intentionally get no prior context.
     history = None
     if not meeting_id:
         history = await build_history(room, agent.name, db)
+
+    # Per-(room, agent) stable id. Lets the agent's session store key
+    # multi-turn memory to this conversation. Namespaced with ``akela:``
+    # so it can't collide with thread ids minted by other A2A clients
+    # (e.g. Vertex's ``google:<sub>`` falling back via the agent's
+    # principal-id chain).
+    context_id = f"akela:{room}:{agent.name}" if is_individual_chat else None
 
     full_text = ""
     meta = {}
@@ -414,6 +432,13 @@ async def handle_agent_notify(
             full_text, meta, stream_id, final_a2a_state = await call_a2a(
                 agent, content, room, redis_client, history, orchestrator_id,
                 hunt_task_id=hunt_task_id, attachments=attachments,
+                # Individual chat: agent owns its memory via session store
+                # keyed on context_id. Den/Hunt: leave history embedded
+                # in-band (per-agent bubble filter / orchestrator picks
+                # different agents per turn — both require the caller to
+                # control what each agent sees).
+                context_id=context_id,
+                embed_history=not is_individual_chat,
             )
         else:
             # openai-compatible (Hermes gateway, LiteLLM, etc.)


### PR DESCRIPTION
## Why

Akela has three A2A dispatch modes that all share `api/services/a2a_caller.py`:

| Mode | History strategy | Source of truth |
|---|---|---|
| **Individual chat** | Should be agent-owned (one user, one agent, ongoing) | Agent session DB |
| **Den** | Per-agent bubble (caller-filtered) | Akela orchestrator |
| **Hunt** | Akela picks agent per turn | Akela orchestrator |

Today all three text-stuff prior turns into the message body via `_build_message`. That's correct for Den (bubble filtering must be caller-controlled) and Hunt (cross-agent dispatch needs canonical log), but wasteful and architecturally muddy for individual chat where one user has one ongoing conversation with one agent.

The hermes-adapter PR chain finished a SessionDB-backed memory facility on the agent side: each A2A request carrying a `contextId` loads its prior turns from SQLite keyed on that id. Individual chat in Akela is a perfect fit for that; Den/Hunt deliberately are not.

## Justification table

| # | Change | Why | Cost | What breaks if skipped |
|---|---|---|---|---|
| 1 | `call_a2a` / `_call_send` / `_call_stream` / `_build_message` accept keyword-only `context_id: str \| None = None` and `embed_history: bool = True` | Single caller can opt in without forking the codepath. Keyword-only prevents accidental positional binding in existing callsites. Defaults preserve today's behavior for Den/Hunt exactly. | ~10 LoC plumbing + docstrings | No opt-in surface for individual chat |
| 2 | `_build_message` includes `contextId` in the A2A message when set; skips the `[Prior conversation]` block when `embed_history=False` | The actual behavior switch. Agent's session DB keys on `contextId`; with the in-band stuff also gone, agent's prompt is clean and the agent becomes the single source of truth. | ~5 LoC | New flags wire through but produce no behavior change |
| 3 | `endpoint_caller.handle_agent_notify` detects individual chat by `room.startswith("chat-") and not meeting_id and not hunt_task_id`; sets `context_id="akela:{room}:{agent.name}"` and `embed_history=False` for that case only | The only place Akela needs to opt in. The `chat-` prefix is the marker `conversations.py` uses when creating individual chat rooms; project rooms (`proj-*`), the default channel (`general`), meetings (`meeting_id` set), and hunt tasks (`hunt_task_id` set) all stay on the legacy text-stuff path. The `akela:` namespace prevents collision with thread ids minted by other A2A clients. | ~7 LoC + comment block explaining the architectural decision | New flags exist but nothing flips them |

## What this PR does NOT change (deferred)

| Deferred | Why deferred |
|---|---|
| Spec hygiene `type:"text"` → `kind:"text"` on parts | Independent concern (applies to Den/Hunt too); separate PR. Today's hermes-adapter accepts both, so no urgency. |
| `dashboard/src/local-chat.ts` (browser-side BYO path) | Same architectural argument applies, but BYO agents have a different deployment lifecycle. Separate rollout. |
| Skip `build_history` call when `is_individual_chat=True` | The result is just ignored downstream. Pure optimization, not a behavior fix. Easy follow-up if needed. |

## Backward compat

- **Den, Hunt, meeting callers**: bit-for-bit identical to pre-PR behavior. Defaults preserve everything.
- **Individual-chat callers**: each call now sends `contextId` and skips the `[Prior conversation]` block. Requires the agent fleet to have hermes-adapter at the SessionDB version, which is the case for any fleet rebuilt today.
- **A2A v1.0 spec**: `contextId` is a top-level message field, not a vendor extension; agents that don't recognize it ignore it. Forward-compatible.

## Tested

Behavioral verification of `_build_message` with four payload shapes:

| Case | Result |
|---|---|
| Den/Hunt default — history embedded, no contextId | ✓ |
| Individual chat — `context_id` set, no `[Prior conversation]` block, message text is just the user input | ✓ |
| Migration mode — both flags set (history embedded AND `contextId` present, useful for shadow-rollout) | ✓ |
| First-turn individual — no history, `contextId` set | ✓ |

## Verify after deploy

In one terminal on a fleet agent:

```
docker logs -f hermes-agent-<name> 2>&1 | grep '[a2a-rpc]'
```

Then in Akela:
1. Start a NEW individual chat with one agent → first message
2. Send a follow-up referencing prior info (e.g., "what did I just ask?")

Expected:
- `session=akela:chat-<id>:<agent>` identical across both messages → contextId propagation ✓
- Agent answers the follow-up correctly using prior turn → SessionDB load working end-to-end ✓

For Den/Hunt: send a message in `general` or a `proj-*` room → `session=` falls back to whatever the gateway derives (no `akela:` prefix), proving Den/Hunt path is untouched.
