### PR TITLE
fix(a2a): use spec-compliant kind:"text" on outbound message parts

### DIFF
--- a/api/services/a2a_caller.py
+++ b/api/services/a2a_caller.py
@@ -303,8 +303,8 @@ def _build_message(content: str, history: list[dict] | None, attachments: list[d
             role = "User" if turn["role"] == "user" else "Assistant"
             history_lines.append(f"{role}: {turn['content']}")
         context = "\n".join(history_lines)
-        parts.append({"type": "text", "text": f"[Prior conversation]\n{context}\n[End prior conversation]\n\n"})
-    parts.append({"type": "text", "text": content})
+        parts.append({"kind": "text", "text": f"[Prior conversation]\n{context}\n[End prior conversation]\n\n"})
+    parts.append({"kind": "text", "text": content})
     for att in (attachments or []):
         mime = att.get("type", "application/octet-stream")
         b64 = att.get("base64", "")
@@ -320,7 +320,7 @@ def _build_message(content: str, history: list[dict] | None, attachments: list[d
                 text_content = _b64.b64decode(b64).decode("utf-8", errors="replace")
             except Exception:
                 text_content = b64
-            parts.append({"type": "text", "text": f"\n[Attachment: {name}]\n{text_content}"})
+            parts.append({"kind": "text", "text": f"\n[Attachment: {name}]\n{text_content}"})
     return {
         "messageId": str(uuid.uuid4()),
         "role": "user",


### PR DESCRIPTION
## Why

A2A v1.0 changed the part-discriminator field from `type` to `kind` between draft and release. The hermes-adapter receivers Akela talks to today accept both (lenient parser at [a2a_routes.py `_extract_text`](https://github.com/balaji-embedcentrum/hermes-adapter/blob/main/hermes_adapter/gateway/a2a_routes.py)), but stricter A2A receivers — Google Vertex AI, future spec-compliant implementations — reject the legacy form.

Three occurrences in `api/services/a2a_caller.py:_build_message`:
1. `[Prior conversation]` history block
2. User-message text part
3. Per-attachment text-decoded body

All three now use `kind:"text"` matching A2A v1.0.

## Justification table

| Change | Why | Cost | What breaks if skipped |
|---|---|---|---|
| 3× `type:"text"` → `kind:"text"` in `a2a_caller.py:_build_message` | A2A v1.0 spec hygiene; matches what hermes-adapter agents already produce in their **responses** (kind everywhere). Strict third-party receivers reject `type`. | 3-line search-replace | Vertex AI / strict A2A receivers reject Akela's outbound parts. Today's hermes-adapter is lenient so nothing breaks immediately, but tomorrow's might. |

## What this PR explicitly does NOT touch

| Skipped | Why |
|---|---|
| `api/services/endpoint_caller.py:148, 166` | Those are OpenAI Vision multimodal content parts (`type:"text"` / `type:"image_url"`) — different spec entirely. Leaving them alone. |
| `dashboard/src/local-chat.ts` | Browser-side BYO path; same architectural argument applies but separate rollout. |

## Backward compat

- **hermes-adapter** accepts both `type` and `kind` today (verified in `a2a_routes.py:_extract_text` — checks both).
- **Den, Hunt, individual chat** all flow through the same `_build_message`; all three modes get the spec fix simultaneously.
- No callsite changes, no test data changes (no tests reference the part shape directly).

## Sequencing

Independent of #29 (mode flag for individual chat) — different hunks, no conflict. Either can merge first; if both merge, the other auto-rebases without conflict.
